### PR TITLE
Change set -> default in attribute files to prevent node definition pollution.

### DIFF
--- a/attributes/client.rb
+++ b/attributes/client.rb
@@ -24,20 +24,20 @@
 
 case node['platform']
 when "ubuntu","debian"
-  set['nagios']['client']['install_method'] = 'package'
-  set['nagios']['nrpe']['pidfile'] = '/var/run/nagios/nrpe.pid'
+  default['nagios']['client']['install_method'] = 'package'
+  default['nagios']['nrpe']['pidfile'] = '/var/run/nagios/nrpe.pid'
 when "redhat","centos","fedora","scientific"
-  set['nagios']['client']['install_method'] = 'source'
-  set['nagios']['nrpe']['pidfile'] = '/var/run/nrpe.pid'
+  default['nagios']['client']['install_method'] = 'source'
+  default['nagios']['nrpe']['pidfile'] = '/var/run/nrpe.pid'
 else
-  set['nagios']['client']['install_method'] = 'source'
-  set['nagios']['nrpe']['pidfile'] = '/var/run/nrpe.pid'
+  default['nagios']['client']['install_method'] = 'source'
+  default['nagios']['nrpe']['pidfile'] = '/var/run/nrpe.pid'
 end
 
-set['nagios']['nrpe']['home']              = "/usr/lib/nagios"
-set['nagios']['nrpe']['conf_dir']          = "/etc/nagios"
-set['nagios']['nrpe']['dont_blame_nrpe']   = "0"
-set['nagios']['nrpe']['command_timeout']   = "60"
+default['nagios']['nrpe']['home']              = "/usr/lib/nagios"
+default['nagios']['nrpe']['conf_dir']          = "/etc/nagios"
+default['nagios']['nrpe']['dont_blame_nrpe']   = "0"
+default['nagios']['nrpe']['command_timeout']   = "60"
 
 # for plugin from source installation
 default['nagios']['plugins']['url']      = 'http://prdownloads.sourceforge.net/sourceforge/nagiosplug'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,4 +21,4 @@
 default['nagios']['user'] = "nagios"
 default['nagios']['group'] = "nagios"
 
-set['nagios']['plugin_dir'] = "/usr/lib/nagios/plugins"
+default['nagios']['plugin_dir'] = "/usr/lib/nagios/plugins"

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -26,31 +26,31 @@ default['nagios']['pagerduty_key'] = ""
 
 case node['platform']
 when "ubuntu","debian"
-  set['nagios']['server']['install_method'] = 'package'
-  set['nagios']['server']['service_name']   = 'nagios3'
-  set['nagios']['server']['mail_command']   = '/usr/bin/mail'
+  default['nagios']['server']['install_method'] = 'package'
+  default['nagios']['server']['service_name']   = 'nagios3'
+  default['nagios']['server']['mail_command']   = '/usr/bin/mail'
 when "redhat","centos","fedora","scientific"
-  set['nagios']['server']['install_method'] = 'source'
-  set['nagios']['server']['service_name']   = 'nagios'
-  set['nagios']['server']['mail_command']   = '/bin/mail'
+  default['nagios']['server']['install_method'] = 'source'
+  default['nagios']['server']['service_name']   = 'nagios'
+  default['nagios']['server']['mail_command']   = '/bin/mail'
 else
-  set['nagios']['server']['install_method'] = 'source'
-  set['nagios']['server']['service_name']   = 'nagios'
-  set['nagios']['server']['mail_command']   = '/bin/mail'
+  default['nagios']['server']['install_method'] = 'source'
+  default['nagios']['server']['service_name']   = 'nagios'
+  default['nagios']['server']['mail_command']   = '/bin/mail'
 end
 
-set['nagios']['home']       = "/usr/lib/nagios3"
-set['nagios']['conf_dir']   = "/etc/nagios3"
-set['nagios']['config_dir'] = "/etc/nagios3/conf.d"
-set['nagios']['log_dir']    = "/var/log/nagios3"
-set['nagios']['cache_dir']  = "/var/cache/nagios3"
-set['nagios']['state_dir']  = "/var/lib/nagios3"
-set['nagios']['run_dir']    = "/var/run/nagios3"
-set['nagios']['docroot']    = "/usr/share/nagios3/htdocs"
-set['nagios']['enable_ssl'] = false
-set['nagios']['http_port']  = node['nagios']['enable_ssl'] ? "443" : "80"
-set['nagios']['server_name'] = node.has_key?(:domain) ? "nagios.#{domain}" : "nagios"
-set['nagios']['ssl_req'] = "/C=US/ST=Several/L=Locality/O=Example/OU=Operations/" +
+default['nagios']['home']       = "/usr/lib/nagios3"
+default['nagios']['conf_dir']   = "/etc/nagios3"
+default['nagios']['config_dir'] = "/etc/nagios3/conf.d"
+default['nagios']['log_dir']    = "/var/log/nagios3"
+default['nagios']['cache_dir']  = "/var/cache/nagios3"
+default['nagios']['state_dir']  = "/var/lib/nagios3"
+default['nagios']['run_dir']    = "/var/run/nagios3"
+default['nagios']['docroot']    = "/usr/share/nagios3/htdocs"
+default['nagios']['enable_ssl'] = false
+default['nagios']['http_port']  = node['nagios']['enable_ssl'] ? "443" : "80"
+default['nagios']['server_name'] = node.has_key?(:domain) ? "nagios.#{domain}" : "nagios"
+default['nagios']['ssl_req'] = "/C=US/ST=Several/L=Locality/O=Example/OU=Operations/" +
   "CN=#{node['nagios']['server_name']}/emailAddress=ops@#{node['nagios']['server_name']}"
 
 # for server from source installation


### PR DESCRIPTION
A set attribute permanently changes a node's json definition. When a cookbook is depended upon the attributes file is included.

This means that when a node is given the 'nagios::client' recipe the attribute files for nagios, php, and apache are all included.

This causes attributes set at the "normal" level for everything from 'nagios::server' to 'mysql::server' to be set in a 'nagios::client's node definition. This pollution reduces readability and causes confusion.

In the attached commit I've converted all "set" attributes to "default" this will allow the recipes to function identically without adjusting a node's definition unnecessarily.
