### PR TITLE
[COOK-1691] dpkg-set-selections for nagios package password on ubuntu

### DIFF
--- a/recipes/server_package.rb
+++ b/recipes/server_package.rb
@@ -18,7 +18,22 @@
 # limitations under the License.
 #
 
-%w{ 
+if platform?(%w{debian ubuntu})
+
+  # Nagios package requires to enter the admin password
+  # We generate it randomly as it's overwritten later in the config templates
+  random_initial_password = rand(36**16).to_s(36)
+
+  %w{adminpassword adminpassword-repeat}.each do |setting|
+    execute "preseed nagiosadmin password" do
+      command "echo nagios3-cgi nagios3/#{setting} password #{random_initial_password} | debconf-set-selections"
+      not_if 'dpkg -l nagios3'
+    end
+  end
+
+end
+
+%w{
   nagios3
   nagios-nrpe-plugin
   nagios-images


### PR DESCRIPTION
Ubuntu now seems to require a password to be set for the admin ui when the package is installed.

Setting it via dpkg-set-selections
