### PR TITLE
COOK-1717:Add apache2::mod_php5 to the nagios::apache recipe

### DIFF
--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -17,6 +17,7 @@
 include_recipe "apache2"
 include_recipe "apache2::mod_ssl"
 include_recipe "apache2::mod_rewrite"
+include_recipe "apache2::mod_php5"
 
 sysadmins = search(:users, 'groups:sysadmin')
 


### PR DESCRIPTION
php5 packages are required for Nagios server to function
