### PR TITLE
COOK-1949: Don't write out services and hosts that reference hostgroups that don't ...

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -248,7 +248,8 @@ end
 nagios_conf "services" do
   variables(
     :service_hosts => service_hosts,
-    :services => services
+    :services => services,
+    :hostgroups => hostgroups
   )
 end
 
@@ -267,7 +268,8 @@ end
 nagios_conf "hosts" do
   variables(
     :nodes => nodes,
-    :unmanaged_hosts => unmanaged_hosts
+    :unmanaged_hosts => unmanaged_hosts,
+    :hostgroups => hostgroups
   )
 end
 

--- a/templates/default/hosts.cfg.erb
+++ b/templates/default/hosts.cfg.erb
@@ -19,13 +19,13 @@ define host {
   <% if n.run_list.roles.nil? || n.run_list.roles.length == 0 -%>
   hostgroups all,<%= n.os %><% if n.chef_environment != '_default' -%>, <%= n.chef_environment %> <% end -%>
   <% else -%>
-  hostgroups <%= n.run_list.roles.to_a.join(",") %>,<%= n.os %><% if n.chef_environment != '_default' -%>, <%= n.chef_environment %> <% end -%>
+  hostgroups <%= (n.run_list.roles.to_a & @hostgroups).join(",") %>,<%= n.os %><% if n.chef_environment != '_default' -%>, <%= n.chef_environment %> <% end -%>
   <% end -%>
   <% elsif -%>
   <% if n.run_list.roles.nil? || n.run_list.roles.length == 0 -%>
   hostgroups all,<%= n.os %>
   <% else -%>
-  hostgroups <%= n.run_list.roles.to_a.join(",") %>,<%= n['os'] %>
+  hostgroups <%= (n.run_list.roles.to_a & @hostgroups).join(",") %>,<%= n['os'] %>
   <% end -%>
   <% end -%>
 }

--- a/templates/default/services.cfg.erb
+++ b/templates/default/services.cfg.erb
@@ -129,7 +129,7 @@ define service {
 
 # Services defined by data bags
 <% @services.each do |service| -%>
-  <% unless @service_hosts[service['hostgroup_name'].nil? && service['hostgroup_name'] != 'all' ] -%>
+  <% unless service['hostgroup_name'].nil? || !@hostgroups.include?(service['hostgroup_name']) -%>
 define service {
   service_description <%= service['id'] %>
   hostgroup_name <%= service['hostgroup_name'] %>


### PR DESCRIPTION
...exist

This prevents either bad roles on a node or a bad nagios_services
databags from breaking the Nagios server config
