### PR TITLE
[COOK-1785] Rename pagerduty config to avoid re-rendering the template.

### DIFF
--- a/recipes/pagerduty.rb
+++ b/recipes/pagerduty.rb
@@ -41,7 +41,7 @@ package "libcrypt-ssleay-perl" do
   action :install
 end
 
-template "#{node['nagios']['config_dir']}/pagerduty_nagios.cfg" do
+template "#{node['nagios']['config_dir']}/pagerduty.cfg" do
   owner node['nagios']['user']
   group node['nagios']['group']
   mode 00644


### PR DESCRIPTION
The nagios::server recipe moves all files that match __nagios_.cfg out
of the conf.d directory.  Since the pager duty configuration file was
named pagerduty_nagios.cfg, it was being re-rendered on every run.
