### PR TITLE
COOK-2131: Remove gd development packages from client_source recipe

### DIFF
--- a/recipes/client_source.rb
+++ b/recipes/client_source.rb
@@ -21,9 +21,9 @@
 include_recipe "build-essential"
 
 pkgs = value_for_platform_family(
-    ["rhel","fedora"] => %w{ openssl-devel gd-devel },
-    "debian" => %w{ libssl-dev libgd2-xpm-dev },
-    "default" => %w{ libssl-dev libgd2-xpm-dev }
+    ["rhel","fedora"] => "openssl-devel" ,
+    "debian" => "libssl-dev",
+    "default" => "libssl-dev"
   )
 
 pkgs.each do |pkg|


### PR DESCRIPTION
These aren't needed to install NRPE.  Just Nagios server.  They come
with an enormouse number of prereqs including X11 libs
