### PR TITLE
COOK-2241: Add an additional alias for the stylesheets so the page renders correctly

### DIFF
--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -15,6 +15,7 @@
   ScriptAlias /cgi-bin/nagios3 /usr/lib/cgi-bin/nagios3
   ScriptAlias /nagios3/cgi-bin /usr/lib/cgi-bin/nagios3
 
+  Alias /stylesheets /etc/nagios3/stylesheets
   Alias /nagios3/stylesheets /etc/nagios3/stylesheets
   Alias /nagios3 <%= node['nagios']['docroot'] %>
 


### PR DESCRIPTION
Out of the box when a user hits / on the webserver they would see a Nagios site, but the CSS files would not load so it would render incorrectly.  Only /nagios3 would render correctly.  Now they both work
