### PR TITLE
COOK-2134: Correctly use nrpe vs. nagios-nrpe-server when necessary

### DIFF
--- a/attributes/client.rb
+++ b/attributes/client.rb
@@ -27,18 +27,25 @@ when 'debian'
   default['nagios']['client']['install_method']  = 'package'
   default['nagios']['nrpe']['pidfile']           = '/var/run/nagios/nrpe.pid'
   default['nagios']['nrpe']['home']              = '/usr/lib/nagios'
+  if node['nagios']['client']['install_method'] == 'package'
+    default['nagios']['nrpe']['service_name']      = 'nagios-nrpe-server'
+  else
+    default['nagios']['nrpe']['service_name']      = 'nrpe'
+  end
 when 'rhel','fedora'
   default['nagios']['client']['install_method']  = 'source'
   default['nagios']['nrpe']['pidfile']           = '/var/run/nrpe.pid'
   if node['kernel']['machine'] == "i686"
-    default['nagios']['nrpe']['home']            = '/usr/lib/nagios'  
+    default['nagios']['nrpe']['home']            = '/usr/lib/nagios'
   else
     default['nagios']['nrpe']['home']            = '/usr/lib64/nagios'
-  end  
+  end
+  default['nagios']['nrpe']['service_name']      = 'nrpe'
 else
   default['nagios']['client']['install_method']  = 'source'
   default['nagios']['nrpe']['pidfile']           = '/var/run/nrpe.pid'
   default['nagios']['nrpe']['home']              = '/usr/lib/nagios'
+  default['nagios']['nrpe']['service_name']      = 'nrpe'
 end
 
 default['nagios']['nrpe']['conf_dir']          = '/etc/nagios'

--- a/providers/nrpecheck.rb
+++ b/providers/nrpecheck.rb
@@ -33,7 +33,7 @@ action :add do
     group "root"
     mode 00644
     content file_contents
-    notifies :restart, resources(:service => "nagios-nrpe-server")
+    notifies :restart, "service[#{node['nagios']['nrpe']['service_name']}]"
   end
   new_resource.updated_by_last_action(true)
 end
@@ -43,7 +43,7 @@ action :remove do
     Chef::Log.info "Removing #{new_resource.command_name} from #{node['nagios']['nrpe']['conf_dir']}/nrpe.d/"
     file "#{node['nagios']['nrpe']['conf_dir']}/nrpe.d/#{new_resource.command_name}.cfg" do
       action :delete
-      notifies :restart, resources(:service => "nagios-nrpe-server")
+      notifies :restart, "service[#{node['nagios']['nrpe']['service_name']}]"
     end
     new_resource.updated_by_last_action(true)
   end

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -62,10 +62,10 @@ template "#{node['nagios']['nrpe']['conf_dir']}/nrpe.cfg" do
     :mon_host => mon_host,
     :nrpe_directory => "#{node['nagios']['nrpe']['conf_dir']}/nrpe.d"
   )
-  notifies :restart, "service[nagios-nrpe-server]"
+  notifies :restart, "service[#{node['nagios']['nrpe']['service_name']}]"
 end
 
-service "nagios-nrpe-server" do
+service node['nagios']['nrpe']['service_name'] do
   action [:start, :enable]
   supports :restart => true, :reload => true
 end

--- a/recipes/client_source.rb
+++ b/recipes/client_source.rb
@@ -90,7 +90,7 @@ bash "compile-nagios-nrpe" do
   creates "#{node['nagios']['plugin_dir']}/check_nrpe"
 end
 
-template "/etc/init.d/nagios-nrpe-server" do
+template "/etc/init.d/#{node['nagios']['nrpe']['service_name']}" do
   source "nagios-nrpe-server.erb"
   owner "root"
   group "root"

--- a/templates/default/nagios-nrpe-server.erb
+++ b/templates/default/nagios-nrpe-server.erb
@@ -4,8 +4,7 @@
 #
 #  Created 2000-01-03 by jaclu@grm.se
 #
-# nagios-nrpe-server This shell script takes care of starting and stopping
-#               nrpe.
+#  This shell script takes care of starting and stopping nrpe.
 #
 # chkconfig: 2345 80 30
 # description: nrpe is a daemon for a remote nagios server, \
@@ -39,15 +38,15 @@ LockFile=/var/lock/subsys/nrpe
 case "$1" in
   start)
   # Start daemons.
-  echo -n "Starting nagios-nrpe-server: "
+  echo -n "Starting <%= node['nagios']['nrpe']['service_name'] %>: "
   daemon $NrpeBin -c $NrpeCfg -d
   echo
   touch $LockFile
   ;;
   stop)
   # Stop daemons.
-  echo -n "Shutting down nagios-nrpe-server: "
-  killproc nagios-nrpe-server
+  echo -n "Shutting down <%= node['nagios']['nrpe']['service_name'] %>: "
+  killproc <%= node['nagios']['nrpe']['service_name'] %>
   echo
   rm -f $LockFile
   ;;
@@ -56,10 +55,10 @@ case "$1" in
   $0 start
   ;;
   status)
-  status nagios-nrpe-server
+  status <%= node['nagios']['nrpe']['service_name'] %>
   ;;
   *)
-  echo "Usage: nagios-nrpe-server {start|stop|restart|status}"
+  echo "Usage: <%= node['nagios']['nrpe']['service_name'] %> {start|stop|restart|status}"
   exit 1
 esac
 


### PR DESCRIPTION
This fixes a long standing bug where NRPE couldn't be stopped on RHEL
systems because the killproc uses the nagios-nrpe-server name.

NRPE is nrpe on RHEL based systems and on source installs, but Debian packages it as nagios-nrpe-server.  Previosly Chef assumed everything was nagios-nrpe-server, which didn't work.
