### PR TITLE
[COOK-2285] Refactor data bag searches into library

### DIFF
--- a/libraries/data_bag_helper.rb
+++ b/libraries/data_bag_helper.rb
@@ -1,4 +1,5 @@
 class NagiosDataBags
+  attr_accessor :bag_list
 
   def initialize(bag_list=Chef::DataBag.list)
     @bag_list = bag_list

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -132,7 +132,7 @@ end
 # Load search defined Nagios hostgroups from the nagios_hostgroups data bag and find nodes
 hostgroup_nodes= Hash.new
 hostgroup_list = Array.new
-if data_bags.include?("nagios_hostgroups")
+if nagios_bags.bag_list.include?("nagios_hostgroups")
   search(:nagios_hostgroups, '*:*') do |hg|
     hostgroup_list << hg['hostgroup_name']
     temp_hostgroup_array= Array.new


### PR DESCRIPTION
This series of commits extracts the searches for data bags into a library to avoid repeated code.  It also avoids searches where possible by consulting a list of known data bags before searching.
