### PR TITLE
COOK-2295: Prevent chef from trying to start NRPE on every run on debian/ubuntu

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -67,7 +67,7 @@ end
 
 service node['nagios']['nrpe']['service_name'] do
   action [:start, :enable]
-  supports :restart => true, :reload => true
+  supports :restart => true, :reload => true, :status => true
 end
 
 # Use NRPE LWRP to define a few checks


### PR DESCRIPTION
Use pattern "nrpe" so that chef can tell if NRPE is actually running.
