### PR TITLE
[COOK-2459] Fix template syntax error in hosts.cfg.erb

### DIFF
--- a/templates/default/hosts.cfg.erb
+++ b/templates/default/hosts.cfg.erb
@@ -21,9 +21,9 @@ define host {
   # if the cloud IP is nil then use the standard IP address attribute.  This is a work around
   #   for OHAI incorrectly identifying systems on Cisco hardware as being in Rackspace
   if node['cloud'].nil? && !n['cloud'].nil?
-    ip = n['cloud']['public_ipv4'] if node['ipaddress'].include? '.' else n['ipaddress']
+    ip = node['ipaddress'].include? '.' ? n['cloud']['public_ipv4'] : n['ipaddress']
   elsif !node['cloud'].nil? && n['cloud']['provider'] != node['cloud']['provider']
-    ip = n['cloud']['public_ipv4'] if node['ipaddress'].include? '.' else n['ipaddress']
+    ip = node['ipaddress'].include? '.' ? n['cloud']['public_ipv4'] : n['ipaddress']
   else
     ip = n['ipaddress']
   end %>


### PR DESCRIPTION
Fix template syntax so that cookbook can be uploaded to Chef server. Was experiencing the following error:

```
FATAL: Erb template templates/default/hosts.cfg.erb has a syntax error:
FATAL: -:25: syntax error, unexpected keyword_elsif, expecting keyword_end
FATAL:   elsif !node['cloud'].nil? && n['cl...
FATAL:        ^
FATAL: -:27: syntax error, unexpected keyword_else, expecting keyword_end
```
