### PR TITLE
fix syntax errors

### DIFF
--- a/templates/default/hosts.cfg.erb
+++ b/templates/default/hosts.cfg.erb
@@ -21,9 +21,9 @@ define host {
   # if the cloud IP is nil then use the standard IP address attribute.  This is a work around
   #   for OHAI incorrectly identifying systems on Cisco hardware as being in Rackspace
   if node['cloud'].nil? && !n['cloud'].nil?
-    ip = n['cloud']['public_ipv4'] if node['ipaddress'].include? '.' else n['ipaddress']
+    ip = node['ipaddress'].include? '.' ? n['cloud']['public_ipv4'] : n['ipaddress']
   elsif !node['cloud'].nil? && n['cloud']['provider'] != node['cloud']['provider']
-    ip = n['cloud']['public_ipv4'] if node['ipaddress'].include? '.' else n['ipaddress']
+    ip = node['ipaddress'].include? '.' ? n['cloud']['public_ipv4'] : n['ipaddress']
   else
     ip = n['ipaddress']
   end %>
@@ -35,7 +35,7 @@ define host {
   <% else -%>
   hostgroups <%= (n.run_list.roles.to_a & @hostgroups).join(",") %>,<%= n.os %>, <%= n.chef_environment %>
   <% end -%>
-  <% elsif -%>
+  <% else -%>
   <% if n.run_list.roles.nil? || n.run_list.roles.length == 0 -%>
   hostgroups all,<%= n.os %>
   <% else -%>


### PR DESCRIPTION
- change single-line if else assignment to ternary
- change elsif with no comparison to just else

Copied from [opscode ticket](http://tickets.opscode.com/browse/COOK-2462):

> I tried uploading the Nagios cookbook to my chef server but I got the following error:
> 
> FATAL: Erb template templates/default/hosts.cfg.erb has a syntax error:
> FATAL: -:25: syntax error, unexpected keyword_elsif, expecting keyword_end
> FATAL:   elsif !node['cloud'].nil? && n['cl...
> FATAL:        ^
> FATAL: -:27: syntax error, unexpected keyword_else, expecting keyword_end
