### PR TITLE
[COOK-2474] don't assume node has cloud attributes

### DIFF
--- a/templates/default/hosts.cfg.erb
+++ b/templates/default/hosts.cfg.erb
@@ -23,7 +23,7 @@ define host {
   #   for OHAI incorrectly identifying systems on Cisco hardware as being in Rackspace
   if node['cloud'].nil? && !n['cloud'].nil?
     ip = node['ipaddress'].include?('.') ? n['cloud']['public_ipv4'] : n['ipaddress']
-  elsif !node['cloud'].nil? && n['cloud']['provider'] != node['cloud']['provider']
+  elsif !node['cloud'].nil? && !n['cloud'].nil? && n['cloud']['provider'] != node['cloud']['provider']
     ip = node['ipaddress'].include?('.') ? n['cloud']['public_ipv4'] : n['ipaddress']
   else
     ip = n['ipaddress']


### PR DESCRIPTION
Prior to this the cookbook assumed if the server node had a cloud
attributes, every node had the cloud attributes, this removes this
assumption.
