### PR TITLE
[COOK-2546] nrpe config files should not be world readable

### DIFF
--- a/providers/nrpecheck.rb
+++ b/providers/nrpecheck.rb
@@ -31,7 +31,7 @@ action :add do
   file "#{node['nagios']['nrpe']['conf_dir']}/nrpe.d/#{new_resource.command_name}.cfg" do
     owner "root"
     group "root"
-    mode 00644
+    mode 00640
     content file_contents
     notifies :restart, "service[#{node['nagios']['nrpe']['service_name']}]"
   end

--- a/recipes/pagerduty.rb
+++ b/recipes/pagerduty.rb
@@ -44,7 +44,7 @@ end
 template "#{node['nagios']['config_dir']}/pagerduty.cfg" do
   owner node['nagios']['user']
   group node['nagios']['group']
-  mode 00644
+  mode 00640
   source "pagerduty_nagios.cfg.erb"
 end
 


### PR DESCRIPTION
They can contain sensitive info like passwords, keys, etc.
