### PR TITLE
COOK-2612: Fix syntax if nagios_hostgroups data bag based search returns nothing

### DIFF
--- a/templates/default/hostgroups.cfg.erb
+++ b/templates/default/hostgroups.cfg.erb
@@ -15,15 +15,12 @@ define hostgroup {
 }
 
 <% end -%>
-
 <% @search_hostgroups.sort.each do |hostgroup| -%>
 define hostgroup {
   hostgroup_name <%= hostgroup %>
   alias <%= hostgroup %>
 <% if @search_nodes[hostgroup].length > 0 -%>
   members        <%= @search_nodes[hostgroup] %>
-<% else -%>
-  members        empty
 <% end -%>
 }
 


### PR DESCRIPTION
Don't write out "members empty" if nothing comes back from the search.
Instead write out a host group with nothing, which is actually correct.
 Also remove an empty line so that there is a single empty line between
each host group definition.
