### PR TITLE
COOK-2613: Install Nagios 3.5.0 when installing from source

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -55,8 +55,8 @@ default['nagios']['ssl_req'] = '/C=US/ST=Several/L=Locality/O=Example/OU=Operati
 
 # for server from source installation
 default['nagios']['server']['url']      = 'http://prdownloads.sourceforge.net/sourceforge/nagios'
-default['nagios']['server']['version']  = '3.4.4'
-default['nagios']['server']['checksum'] = 'cf6c4c82c4d8dd42e5daae92c20682574f001f03d062600327372c8274fc338e'
+default['nagios']['server']['version']  = '3.5.0'
+default['nagios']['server']['checksum'] = '469381b2954392689c85d3db733e8da4bd43b806b3d661d1a7fbd52dacc084db'
 
 default['nagios']['notifications_enabled']   = 0
 default['nagios']['check_external_commands'] = true


### PR DESCRIPTION
Bug fixes:

```
Fixed bug #403: The "configuration" page of the webui doesn't use
```

entity encoding when displaying the "command expansion" item (Eric
Stanley, Phil Randal)
    Fixed bug #424: Nagios Core 3.4.4 seg fault (core dump) on restart
after removing config for running service (Eric Stanley)
    Updated CGI utility functions to support UTF-8 characters (Eric
Stanley)
    Fixed bug where selecting Command Expansion from Configuration CGI
page would display commands instead (Eric Stanley)
    Fixed bug #369: status.cgi crashes with segfault when there are
german ulauts (äöüß) in the hostname or the servicename (Eric Stanley)
    Fixed bug #418: Scheduled Downtime Notifications Resent On Nagios
Restart/reload (Eric Stanley)
