### PR TITLE
COOK-2658: Clarify what OS types have been tested for server vs. client

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,16 @@ The system running the 'server' recipe should have a role named 'monitoring' so 
 Platform
 --------
 
+__Client:__
+
 * Debian 6
 * Ubuntu 10.04, 12.04
 * Red Hat Enterprise Linux (CentOS/Amazon/Scientific/Oracle) 5.8, 6.3
+
+__Server:__
+
+* Debian 6
+* Ubuntu 10.04, 12.04
 
 **Notes**: This cookbook has been tested on the listed platforms. It
   may work on other platforms with or without modification.


### PR DESCRIPTION
Ubuntu 10.04/12.04 and Debian 6 have been tested with source/package
installs for server.  RHEL 5/6 have been tested with client installs.
