### PR TITLE
[COOK-2721] Use n['foo'] instead of n.foo to support chef-solo.

### DIFF
--- a/templates/default/hosts.cfg.erb
+++ b/templates/default/hosts.cfg.erb
@@ -11,7 +11,7 @@ define host {
 }
 
 <% @nodes.each do |n| -%>
-<% unless n['name'] == node.name -%>
+<% unless n.name == node.name -%>
 define host {
   use server
   <% # decide whether to use internal or external IP addresses for this node
@@ -32,9 +32,9 @@ define host {
   host_name <%= node['nagios']['server']['normalize_hostname'] ? n[node['nagios']['host_name_attribute']].downcase : n[node['nagios']['host_name_attribute']] %>
   <% if node['nagios']['multi_environment_monitoring'] -%>
   <% if n['roles'].nil? || n['roles'].length == 0 -%>
-  hostgroups all,<%= n['os'] %>, <%= n['chef_environment'] %>
+  hostgroups all,<%= n['os'] %>, <%= n.chef_environment %>
   <% else -%>
-  hostgroups all,<%= (n['roles'] & @hostgroups).join(",") %>,<%= n['os'] %>, <%= n['chef_environment'] %>
+  hostgroups all,<%= (n['roles'] & @hostgroups).join(",") %>,<%= n['os'] %>, <%= n.chef_environment %>
   <% end -%>
   <% elsif -%>
   <% if n['roles'].nil? || n['roles'].length == 0 -%>


### PR DESCRIPTION
This pull request make the nagios cookbook to be supported in chef-solo.
Please refer the ticket
http://tickets.opscode.com/browse/COOK-2721
