### PR TITLE
NRPE LWRP always flags files inside nrpe.d as having been updated

### DIFF
--- a/providers/nrpecheck.rb
+++ b/providers/nrpecheck.rb
@@ -35,7 +35,6 @@ action :add do
     content file_contents
     notifies :restart, "service[#{node['nagios']['nrpe']['service_name']}]"
   end
-  new_resource.updated_by_last_action(true)
 end
 
 action :remove do


### PR DESCRIPTION
Remove code that manually sets the updated status for the NRPE LWRP files. The file provider will set this if it actually updates the file, we should not be setting it as updated even when it has not been. See COOK-3021.
