### PR TITLE
COOK-3282: Utilize the host_name_attribute when writing out hostgroups from nagios_hostgroups

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -169,11 +169,11 @@ if nagios_bags.bag_list.include?("nagios_hostgroups")
     temp_hostgroup_array= Array.new
     if node['nagios']['multi_environment_monitoring']
       search(:node, hg['search_query']) do |n|
-        temp_hostgroup_array << n['hostname']
+        temp_hostgroup_array << n[node['nagios']['host_name_attribute']]
       end
     else
       search(:node, "#{hg['search_query']} AND chef_environment:#{node.chef_environment}") do |n|
-        temp_hostgroup_array << n['hostname']
+        temp_hostgroup_array << n[node['nagios']['host_name_attribute']]
       end
     end
     hostgroup_nodes[hg['hostgroup_name']] = temp_hostgroup_array.join(",")


### PR DESCRIPTION
A small bug: when integrating search-defined hostgroups with a custom host_name_attribute, it causes Nagios to be unable to parse the configuration.
