### PR TITLE
[COOK-3332] nagios::client fails under chef-solo

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -32,7 +32,7 @@ elsif node['nagios']['multi_environment_monitoring']
   search(:node, "role:#{node['nagios']['server_role']}") do |n|
     mon_host << n['ipaddress']
   end
-else
+elsif !Chef::Config[:solo]
   search(:node, "role:#{node['nagios']['server_role']} AND chef_environment:#{node.chef_environment}") do |n|
     mon_host << n['ipaddress']
   end


### PR DESCRIPTION
I started using this recipe in a cookbook I run through test-kitchen and it blows up because it trys to execute a search. Letting it set to 127.0.0.1 is all I need to verify things in test-kitchen. 
