### PR TITLE
[COOK-3690] add attribute for optional intermediate ssl certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The following attributes are used for the Nagios server
 * `node['nagios']['timezone']` - Nagios timezone, defaults to UTC
 * `node['nagios']['enable_ssl]` - boolean for whether Nagios web server should be https, default false
 * `node['nagios']['ssl_cert_file']` = Location of SSL Certificate File. default "/etc/nagios3/certificates/nagios-server.pem"
+* `node['nagios']['ssl_cert_chain_file']` = Optional location of SSL Intermediate Certificate File. No default. 
 * `node['nagios']['ssl_cert_key']`  = Location of SSL Certificate Key. default "/etc/nagios3/certificates/nagios-server.pem"
 * `node['nagios']['http_port']` - port that the Apache/Nginx virtual site should listen on, determined whether ssl is enabled (443 if so, otherwise 80). Note:  You will also need to configure the listening port for either NGINX or Apache within those cookbooks.
 * `node['nagios']['server_name']` - common name to use in a server cert, default "nagios"

--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -22,6 +22,9 @@
   <% if @https -%>
   SSLEngine On
   SSLCertificateFile <%= @ssl_cert_file %>
+  <% if node['nagios']['ssl_cert_chain_file'] %>
+  SSLCertificateChainFile <%= node['nagios']['ssl_cert_chain_file'] %>
+  <% end -%>
   SSLCertificateKeyFile <%= @ssl_cert_key %>
   <% end -%>
 


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3690

This pull request allows the user to specify the location of an intermediate SSL certificate using the optional attribute node['nagios']['ssl_cert_chain_file']

If this attribute is set, a "SSLCertificateChainFile" directive is added to the Apache2 config file.
