### PR TITLE
[COOK-3695] Add more tunable directives for default host

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,15 +104,20 @@ The following attributes are used for the Nagios server
 * `node['nagios']['templates']`
 * `node['nagios']['interval_length']` - minimum interval.
 
-* `node['nagios']['default_host']['check_interval']`
-* `node['nagios']['default_host']['retry_interval']`
-* `node['nagios']['default_host']['max_check_attempts']`
-* `node['nagios']['default_host']['notification_interval']`
+These set directives in the default host template. Unless explicitly
+overridden, they will be inheirited by the host definitions for each
+disovered node and `nagios_unmanagedhosts` data bag. For more
+information about these directives, see the Nagios documentation for
+[host definitions](http://nagios.sourceforge.net/docs/3_0/objectdefinitions.html#host).
 
-* `node['nagios']['default_service']['check_interval']`
-* `node['nagios']['default_service']['retry_interval']`
-* `node['nagios']['default_service']['max_check_attempts']`
-* `node['nagios']['default_service']['notification_interval']`
+* `node['nagios']['default_host']['flap_detection']` - Defaults to `true`.
+* `node['nagios']['default_host']['check_period']` - Defaults to `'24x7'`.
+* `node['nagios']['default_host']['check_interval']` - In seconds. Must be divisible by `node['nagios']['interval_length']`. Defaults to `15`.
+* `node['nagios']['default_host']['retry_interval']` - In seconds. Must be divisible by `node['nagios']['interval_length']`. Defaults to `15`.
+* `node['nagios']['default_host']['max_check_attempts']` - Defaults to `1`.
+* `node['nagios']['default_host']['check_command']` - Defaults to the pre-defined command `'check-host-alive'`.
+* `node['nagios']['default_host']['notification_interval']` - In seconds. Must be divisible by `node['nagios']['interval_length']`. Defaults to `300`.
+* `node['nagios']['default_host']['notification_options']` - Defaults to `'d,u,r'`.
 
 * `node['nagios']['server']['web_server']` - web server to use. supports Apache or Nginx, default "apache"
 * `node['nagios']['server']['nginx_dispatch']` - nginx dispatch method. support cgi or php, default "cgi"

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -94,12 +94,15 @@ default['nagios']['ldap_authoritative'] = nil
 default['nagios']['templates']       = Mash.new
 default['nagios']['interval_length'] = 1
 
+default['nagios']['default_host']['flap_detection']        = true
+default['nagios']['default_host']['check_period']          = '24x7'
 # Provide all interval values in seconds
 default['nagios']['default_host']['check_interval']        = 15
 default['nagios']['default_host']['retry_interval']        = 15
 default['nagios']['default_host']['max_check_attempts']    = 1
+default['nagios']['default_host']['check_command']         = 'check-host-alive'
 default['nagios']['default_host']['notification_interval'] = 300
-default['nagios']['default_host']['flap_detection']        = true
+default['nagios']['default_host']['notification_options']  = 'd,u,r'
 
 default['nagios']['default_service']['check_interval']        = 60
 default['nagios']['default_service']['retry_interval']        = 15

--- a/templates/default/templates.cfg.erb
+++ b/templates/default/templates.cfg.erb
@@ -43,13 +43,13 @@ define host {
 define host {
   name                    server
   use                     default-host
-  check_period            24x7
+  check_period            <%= nagios_attr(:default_host)[:check_period] %>
   check_interval          <%= nagios_interval(nagios_attr(:default_host)[:check_interval]) %>
   retry_interval          <%= nagios_interval(nagios_attr(:default_host)[:retry_interval]) %>
   max_check_attempts      <%= nagios_attr(:default_host)[:max_check_attempts] %>
-  check_command           check-host-alive
+  check_command           <%= nagios_attr(:default_host)[:check_command] %>
   notification_interval   <%= nagios_interval(nagios_attr(:default_host)[:notification_interval]) %>
-  notification_options    d,u,r
+  notification_options    <%= nagios_attr(:default_host)[:notification_options] %>
   contact_groups          <%= nagios_attr(:default_contact_groups).join(",") %>
   register                0
 }


### PR DESCRIPTION
Adds `check_period`, `check_command` & `notification_options` attributes
for tuning the default host template. Also added a bunch of docs for the
`node['nagios']['default_host']` attributes.

Ticket: https://tickets.opscode.com/browse/COOK-3695
