### PR TITLE
[COOK-3731] Remove unncessary range searches that break chef-zero

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -106,9 +106,9 @@ nodes = []
 hostgroups = []
 
 if node['nagios']['multi_environment_monitoring']
-  nodes = search(:node, 'hostname:[* TO *]')
+  nodes = search(:node, 'hostname:*')
 else
-  nodes = search(:node, "hostname:[* TO *] AND chef_environment:#{node.chef_environment}")
+  nodes = search(:node, "hostname:* AND chef_environment:#{node.chef_environment}")
 end
 
 if nodes.empty?


### PR DESCRIPTION
Range searches aren't necessary here and the current release of chef-zero cannot handle them.  This is necessary to implement Test Kitchen using chef-zero
