### PR TITLE
Added ability to exclude hosts on the chef server from being monitored, fixed _default hostgroup issue when using multi_environment_mode 

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -127,3 +127,5 @@ default['nagios']['server']['nginx_dispatch'] = :cgi
 default['nagios']['server']['stop_apache']    = false
 default['nagios']['server']['redirect_root']  = false
 default['nagios']['server']['normalize_hostname'] = false
+# array of hostnames to exclude from being monitored
+default['nagios']['server']['exclude_hosts'] = []

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -105,10 +105,13 @@ Chef::Log.info('Beginning search for nodes.  This may take some time depending o
 nodes = []
 hostgroups = []
 
+# filter monitored hosts by excluding them from the initial node search
+exclude_hosts = "NOT hostname:"+node['nagios']['server']['exclude_hosts'].join(" NOT hostname:")
+
 if node['nagios']['multi_environment_monitoring']
-  nodes = search(:node, 'hostname:*')
+  nodes = search(:node, "hostname:* #{exclude_hosts}" )
 else
-  nodes = search(:node, "hostname:* AND chef_environment:#{node.chef_environment}")
+  nodes = search(:node, "hostname:* AND chef_environment:#{node.chef_environment} #{exclude_hosts}" )
 end
 
 if nodes.empty?


### PR DESCRIPTION
The following changes allow you to define an array ['nagios']['server']['exclude_hosts'] which will then be excluded from the search that pulls the nodes to be monitored. Slightly crude, but it works and I've seen other people mention that it would be a nice feature to have.
