### PR TITLE
Update servicedependencies.cfg.erb

### DIFF
--- a/templates/default/servicedependencies.cfg.erb
+++ b/templates/default/servicedependencies.cfg.erb
@@ -19,7 +19,7 @@ define servicedependency{
   host_name			<%= servicedependency['host_name'] %>
 <% end -%>
 <% if servicedependency['hostgroup_name'] -%>
-  hostgroup_name		<%= servicedependency['hotsgroup_name'] %>
+  hostgroup_name		<%= servicedependency['hostgroup_name'] %>
 <% end -%>
 <% if servicedependency['service_description'] -%>
   service_description		<%= servicedependency['service_description'] %>


### PR DESCRIPTION
Fixed spelling error that caused hostgroup_name to always show a nil value.
