### PR TITLE
Search by node name not hostname

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -106,9 +106,9 @@ nodes = []
 hostgroups = []
 
 if node['nagios']['multi_environment_monitoring']
-  nodes = search(:node, 'fqdn:*')
+  nodes = search(:node, 'name:*')
 else
-  nodes = search(:node, "fqdn:* AND chef_environment:#{node.chef_environment}")
+  nodes = search(:node, "name:* AND chef_environment:#{node.chef_environment}")
 end
 
 if nodes.empty?


### PR DESCRIPTION
This pulls the node by what you called it and therefore matches what we really are looking for. For some reason this would break on windows hosts.
