### PR TITLE
The example for Contact Groups is bad

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Example `nagios_contactgroup` data bag item
 {
   "id": "non_admins",
   "alias": "Non-Administrator Contacts",
-  "members": "devs helpdesk managers"
+  "members": "devs,helpdesk,managers"
 }
 ```
 


### PR DESCRIPTION
'members' value in nagoios_contactgroups data bag needs to be comma delimited:

http://nagios.sourceforge.net/docs/3_0/objectdefinitions.html#contactgroup
