### PR TITLE
Fix cookbook crash if a node has no roles

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -123,7 +123,7 @@ nodes.sort! { |a, b| a.name <=> b.name }
 service_hosts = {}
 search(:role, '*:*') do |r|
   hostgroups << r.name
-  nodes.select { |n| n['roles'].include?(r.name) }.each do |n|
+  nodes.select { |n| n['roles'].include?(r.name) if n['roles'] }.each do |n|
     service_hosts[r.name] = n[node['nagios']['host_name_attribute']]
   end
 end


### PR DESCRIPTION
This fixes a failed chef run if a node doesn't have any roles yet.
