### PR TITLE
Fix using wrong pagerduty key attribute

### DIFF
--- a/templates/default/pagerduty.cfg.erb
+++ b/templates/default/pagerduty.cfg.erb
@@ -11,8 +11,8 @@ define command {
        command_name     notify-host-by-pagerduty
        command_line     <%= ::File.join(node['nagios']['plugin_dir'], "notify_pagerduty.pl") %> enqueue -f pd_nagios_object=host
 }
-<% unless node["nagios"]["pagerduty_key"].empty? -%>
 
+<% unless node['nagios']['pagerduty']['key'].nil? || node['nagios']['pagerduty']['key'].empty? -%>
 define contact {
        contact_name                             pagerduty
        alias                                    PagerDuty Pseudo-Contact


### PR DESCRIPTION
Also fix the case where the attribute can be nil causing a cookbook
failure when using the old attribute name.

[COOK-4315](https://tickets.opscode.com/browse/COOK-4315)
