### PR TITLE
Fix cookbook crash if a node is missing a hostname

### DIFF
--- a/templates/default/hosts.cfg.erb
+++ b/templates/default/hosts.cfg.erb
@@ -15,7 +15,8 @@ define host {
 define host {
   use server
   address <%= ip_to_monitor(n) %>
-  host_name <%= node['nagios']['server']['normalize_hostname'] ? n[node['nagios']['host_name_attribute']].downcase : n[node['nagios']['host_name_attribute']] %>
+  <% host_name = (n[node['nagios']['host_name_attribute']] ? n[node['nagios']['host_name_attribute']] : n.name) -%>
+  host_name <%= node['nagios']['server']['normalize_hostname'] ? host_name.downcase : host_name %>
   <% if node['nagios']['multi_environment_monitoring'] -%>
   <% if n['roles'].nil? || n['roles'].length == 0 -%>
   hostgroups all,<%= n['os'] %>, <%= n.chef_environment %>


### PR DESCRIPTION
There are cases where ohai cannot determine a fqdn for a node (like if
dns is not working) and node['hostname'] can be nil.  This deals with
that situation by returning the node name in place of the hostname if
node['hostname'] is nil.
