### PR TITLE
Support for broker modules is added to nagios.cfg

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -143,6 +143,7 @@ default['nagios']['conf']['p1_file']                  = "#{node['nagios']['home'
 default['nagios']['conf']['debug_level']              = 0
 default['nagios']['conf']['debug_verbosity']          = 1
 default['nagios']['conf']['debug_file']               = "#{node['nagios']['state_dir']}/#{node['nagios']['server']['name']}.debug"
+default['nagios']['conf']['broker_modules']           = %w{}
 
 default['nagios']['cgi']['show_context_help']                        = 1
 default['nagios']['cgi']['authorized_for_system_information']        = '*'

--- a/templates/default/nagios.cfg.erb
+++ b/templates/default/nagios.cfg.erb
@@ -25,6 +25,10 @@ external_command_buffer_slots=4096
 lock_file=<%= node['nagios']['run_dir'] %>/<%= node['nagios']['server']['vname'] %>.pid
 temp_file=<%= node['nagios']['cache_dir'] %>/<%= node['nagios']['server']['name'] %>.tmp
 temp_path=/tmp
+
+<% node['nagios']['conf']['broker_modules'].each do |brokermodule| -%>
+<%= "broker_module=#{brokermodule}"%>
+<% end %>
 event_broker_options=-1
 
 log_rotation_method=d


### PR DESCRIPTION
I needed to install Livestatus API for Nagios. But it requires to set broker_module to nagios.cfg
I added an array to attributes to be able to add more than one broker module if needed.
