### PR TITLE
prevent node['os'] when nil to be added to hostgroups; happened with chef-zero and not fully bootsraped nodes

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -147,7 +147,7 @@ end
 
 # Add all unique platforms to the array of hostgroups
 nodes.each do |n|
-  hostgroups << n['os'] unless hostgroups.include?(n['os'])
+  hostgroups << n['os'] unless hostgroups.include?(n['os']) || n['os'].nil?
 end
 
 nagios_bags         = NagiosDataBags.new


### PR DESCRIPTION
Nodes created with chef-zero will not have the 'os' attribute on the first run when returned in the search results. This will just prevent to add the string nil to the list of hostgroups in this case. 
