### PR TITLE
Templatize the nagios obsess config options

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -90,6 +90,11 @@ default['nagios']['accept_passive_service_checks'] = 1
 default['nagios']['execute_host_checks']           = 1
 default['nagios']['accept_passive_host_checks']    = 1
 
+default['nagios']['obsess_over_services'] = 0
+default['nagios']['ocsp_command']         = nil
+default['nagios']['obsess_over_hosts']    = 0
+default['nagios']['ochp_command']         = nil
+
 default['nagios']['check_external_commands']     = true
 default['nagios']['default_contact_groups']      = %w{admins}
 default['nagios']['sysadmin_email']              = 'root@localhost'

--- a/templates/default/nagios.cfg.erb
+++ b/templates/default/nagios.cfg.erb
@@ -110,10 +110,18 @@ process_performance_data=<%= node['nagios']['conf']['process_performance_data'] 
 #host_perfdata_file_processing_command=process-host-perfdata-file
 #service_perfdata_file_processing_command=process-service-perfdata-file
 
-obsess_over_services=0
+obsess_over_services=<%= node['nagios']['obsess_over_services'] %>
+<% if node['nagios']['ocsp_command'] -%>
+oscp_command='<%= node['nagios']['ocsp_command'] %>'
+<% else -%>
 #ocsp_command=somecommand
-obsess_over_hosts=0
+<% end -%>
+obsess_over_hosts=<%= node['nagios']['obsess_over_hosts'] %>
+<% if node['nagios']['ochp_command'] -%>
+ochp_command='<%= node['nagios']['ochp_command'] %>'
+<% else -%>
 #ochp_command=somecommand
+<% end -%>
 translate_passive_host_checks=0
 passive_host_checks_are_soft=0
 check_for_orphaned_services=1


### PR DESCRIPTION
This allows setting/changing the following options:

obsess_over_services
ocsp_command
obsess_over_hosts
ochp_command

These are generally needed when setting up failover servers.
