### PR TITLE
Added reload to the NRPE client service & modified the LWRP to call this

### DIFF
--- a/providers/nrpecheck.rb
+++ b/providers/nrpecheck.rb
@@ -33,7 +33,7 @@ action :add do
     group node['nagios']['group']
     mode 00640
     content file_contents
-    notifies :restart, "service[#{node['nagios']['nrpe']['service_name']}]"
+    notifies :reload, "service[#{node['nagios']['nrpe']['service_name']}]"
   end
   new_resource.updated_by_last_action(f.updated_by_last_action?)
 end
@@ -43,7 +43,7 @@ action :remove do
     Chef::Log.info "Removing #{new_resource.command_name} from #{node['nagios']['nrpe']['conf_dir']}/nrpe.d/"
     f = file "#{node['nagios']['nrpe']['conf_dir']}/nrpe.d/#{new_resource.command_name}.cfg" do
       action :delete
-      notifies :restart, "service[#{node['nagios']['nrpe']['service_name']}]"
+      notifies :reload, "service[#{node['nagios']['nrpe']['service_name']}]"
     end
     new_resource.updated_by_last_action(f.updated_by_last_action?)
   end

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -67,5 +67,5 @@ end
 
 service node['nagios']['nrpe']['service_name'] do
   action [:start, :enable]
-  supports :restart => true, :status => false
+  supports :restart => true, :reload => true, :status => true
 end


### PR DESCRIPTION
rather than restart. This stops unneeded crits being generated as a
result of adding or removing a check via the LWRP - reloading NRPE is
graceful, restarting is not.
