### PR TITLE
Create the "archives" log directory for source installs

### DIFF
--- a/recipes/server_source.rb
+++ b/recipes/server_source.rb
@@ -116,6 +116,12 @@ end
 
 end
 
+directory ::File.join(node['nagios']['log_dir'], 'archives') do
+  owner node['nagios']['user']
+  group node['nagios']['group']
+  mode '0755'
+end
+
 directory "/usr/lib/#{node['nagios']['server']['vname']}" do
   owner node['nagios']['user']
   group node['nagios']['group']


### PR DESCRIPTION
Not creating this directory causes an error when trying to start up nagios.
