### PR TITLE
Don't include p1_file config option if it's not set (fixes problem with nagios starting up)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,7 +48,6 @@ when 'debian'
   default['nagios']['server']['install_method'] = 'package'
   default['nagios']['server']['service_name']   = 'nagios3'
   default['nagios']['server']['mail_command']   = '/usr/bin/mail'
-  default['nagios']['conf']['p1_file']          = "#{node['nagios']['home']}/p1.pl"
 when 'rhel', 'fedora'
   default['nagios']['conf']['p1_file']          = '/usr/sbin/p1.pl'
   # install via package on RHEL releases less than 6, otherwise use packages

--- a/templates/default/nagios.cfg.erb
+++ b/templates/default/nagios.cfg.erb
@@ -142,7 +142,9 @@ high_host_flap_threshold=20.0
 date_format=<%= node['nagios']['conf']['date_format'] %>
 
 use_timezone=<%= node['nagios']['timezone'] %>
+<% if node['nagios']['conf']['p1_file'] %>
 p1_file=<%= node['nagios']['conf']['p1_file'] %>
+<% end %>
 enable_embedded_perl=1
 use_embedded_perl_implicitly=1
 


### PR DESCRIPTION
This config value isn't set for the debian family, but is set in the "else" clause. Not setting a value for this causes an error trying to start up nagios (the config file says `p1_file=`).
