### PR TITLE
prevent duplicates hostgroups in case the same roles/environment exist

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -136,7 +136,7 @@ end
 # if using multi environment monitoring add all environments to the array of hostgroups
 if node['nagios']['multi_environment_monitoring']
   search(:environment, '*:*') do |e|
-    hostgroups << e.name
+    hostgroups << e.name unless hostgroups.include?(e.name)
     nodes.select { |n| n.chef_environment == e.name }.each do |n|
       service_hosts[e.name] = n[node['nagios']['host_name_attribute']]
     end


### PR DESCRIPTION
If the same roles and environment names exist in chef this will cause duplicate hostgroups and nagios will not like it and fail to start.
