### PR TITLE
We should be able to monitor a list of chef environments as defined by the node['nagios']['multi_environments'] attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Attributes
 * `node['nagios']['group']` - Nagios group, default 'nagios'.
 * `node['nagios']['plugin_dir']` - location where Nagios plugins go, default '/usr/lib/nagios/plugins'.
 * `node['nagios']['multi_environment_monitoring']` - Chef server will monitor hosts in all environments, not just its own, default 'false'
-* `node['nagios']['multi_environments']` - If multi_environment_monitoring is 'true' nagios will monitor nodes in all environments. If multi_environments is defined then nagios will only monitor hosts in the list of environments defined. For ex: ['prod', 'beta'] will monitor only hosts in 'prod' and 'beta' chef_environments. Defaults to '[]' - and all chef environments will be monitored by default.
+* `node['nagios']['monitored_environments']` - If multi_environment_monitoring is 'true' nagios will monitor nodes in all environments. If monitored_environments is defined then nagios will monitor only hosts in the list of environments defined. For ex: ['prod', 'beta'] will monitor only hosts in 'prod' and 'beta' chef_environments. Defaults to '[]' - and all chef environments will be monitored by default.
 * `node['nagios']['monitoring_interface']` - If set, will use the specified interface for all nagios monitoring network traffic. Defaults to `nil`
 
 * `node['nagios']['server']['install_method']` - whether to install from package or source. Default chosen by platform based on known packages available for Nagios: debian/ubuntu 'package', redhat/centos/fedora/scientific: source

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,7 +22,7 @@
 
 # Allow a Nagios server to monitor hosts in multiple environments.
 default['nagios']['multi_environment_monitoring'] = false
-default['nagios']['multi_environments'] = []
+default['nagios']['monitored_environments'] = []
 
 default['nagios']['user']  = 'nagios'
 default['nagios']['group'] = 'nagios'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -109,7 +109,7 @@ end
 Chef::Log.info('Beginning search for nodes.  This may take some time depending on your node count')
 nodes = []
 hostgroups = []
-multi_env = node['nagios']['multi_environments']
+multi_env = node['nagios']['monitored_environments']
 multi_env_search = multi_env.empty? ? '' : ' AND (chef_environment:' + multi_env.join(' OR chef_environment:') + ')'
 
 if node['nagios']['multi_environment_monitoring']


### PR DESCRIPTION
This adds support for monitoring hosts from a list of environments (besides the current env and all nodes options already there). By default it is disabled, and has no impact unless the node['nagios']['multi_environments'] is defined with an array of environment names. 
