### PR TITLE
allow exclusion hostgroups

### DIFF
--- a/templates/default/services.cfg.erb
+++ b/templates/default/services.cfg.erb
@@ -9,6 +9,10 @@
        valid = false
 
        service['hostgroup_name'].split(",").each do |s|
+         if s[0] == '!'
+           s = s[1, s.length]
+         end
+
          valid = @hostgroups.include?(s) || @search_hostgroups.include?(s)
          valid || break
        end


### PR DESCRIPTION
Hello, 

This change allows hostgroup verification for exclusion patterns as described in http://nagios.sourceforge.net/docs/3_0/objecttricks.html 

For instance,  the nagios_service: 

```
{
  "id": "load",
  "hostgroup_name": "base,!<valid-role>",
  "command_line": "$USER1$/check_nrpe -H $HOSTADDRESS$ -c check_load -t 20"
}
```

will now work as expected for a valid <valid-role> when compared to being dropped as a result of the hostgroup_name check.
