### PR TITLE
Overwrite full nagios vname

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -105,9 +105,9 @@ default['nagios']['ssl_req']       = '/C=US/ST=Several/L=Locality/O=Example/OU=O
 default['nagios']['server']['name']  = 'nagios'
 case node['platform_family']
 when 'rhel', 'fedora'
-  default['nagios']['server']['vname'] = 'nagios'
+  default['nagios']['server']['vname'] = 'nagios.conf'
 else
-  default['nagios']['server']['vname'] = 'nagios3'
+  default['nagios']['server']['vname'] = 'nagios3.conf'
 end
 
 # for server from source installation

--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -25,7 +25,7 @@ apache_site '000-default' do
   enable false
 end
 
-template "#{node['apache']['dir']}/sites-available/#{node['nagios']['server']['vname']}.conf" do
+template "#{node['apache']['dir']}/sites-available/#{node['nagios']['server']['vname']}" do
   source 'apache2.conf.erb'
   mode '0644'
   variables(
@@ -35,13 +35,13 @@ template "#{node['apache']['dir']}/sites-available/#{node['nagios']['server']['v
     :ssl_cert_file => node['nagios']['ssl_cert_file'],
     :ssl_cert_key  => node['nagios']['ssl_cert_key']
   )
-  if File.symlink?("#{node['apache']['dir']}/sites-enabled/#{node['nagios']['server']['vname']}.conf")
+  if File.symlink?("#{node['apache']['dir']}/sites-enabled/#{node['nagios']['server']['vname']}")
     notifies :reload, 'service[apache2]'
   end
 end
 
-file "#{node['apache']['dir']}/conf.d/#{node['nagios']['server']['vname']}.conf" do
+file "#{node['apache']['dir']}/conf.d/#{node['nagios']['server']['vname']}" do
   action :delete
 end
 
-apache_site "#{node['nagios']['server']['vname']}.conf"
+apache_site "#{node['nagios']['server']['vname']}"


### PR DESCRIPTION
I should be able to overwrite full name for apache, fix for debian and default apache2 cookbook, apache trying to enable nagios3.conf.conf.
execute[a2ensite nagios3.conf.conf]
