### PR TITLE
Using node['nagios']['server']['service_name'] for nagios_conf

### DIFF
--- a/definitions/nagios_conf.rb
+++ b/definitions/nagios_conf.rb
@@ -32,7 +32,7 @@ define :nagios_conf, :variables => {}, :config_subdir => true, :source => nil do
     source params[:source]
     mode '0644'
     variables params[:variables]
-    notifies :reload, 'service[nagios]'
+    notifies :reload, "service[#{node['nagios']['server']['service_name']}]"
     backup 0
   end
 end


### PR DESCRIPTION
service name is defined under node['nagios']['server']['service_name'],
this causes reload notification failure on ubuntu because service name
defaults to 'nagios3'
