### PR TITLE
add patch support for source install

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Attributes
 *  `node['nagios']['server']['url']` - url to download the server source from if installing from source
 *  `node['nagios']['server']['version']` - version of the server source to download
 *  `node['nagios']['server']['checksum']` - checksum of the source files
+*  `node['nagios']['server']['patch_url'] - url to download patches from if installing from source
+*  `node['nagios']['server']['patches'] - array of patch filenames to apply if installing from source
 *  `node['nagios']['url']` - URL to host Nagios from - defaults to nil and instead uses  FQDN
 
 * `node['nagios']['notifications_enabled']` - set to 1 to enable notification.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -114,7 +114,9 @@ end
 default['nagios']['server']['url']      = 'http://prdownloads.sourceforge.net/sourceforge/nagios'
 default['nagios']['server']['version']  = '3.5.1'
 default['nagios']['server']['checksum'] = 'ca9dd68234fa090b3c35ecc8767b2c9eb743977eaf32612fa9b8341cc00a0f99'
-default['nagios']['server']['src_dir'] = 'nagios'
+default['nagios']['server']['src_dir']  = 'nagios'
+default['nagios']['server']['patch_url']= nil
+default['nagios']['server']['patches']  = []
 
 # for server from packages installation
 case node['platform_family']


### PR DESCRIPTION
This makes it possible to change the nagios source code with patch files before compiling it. If no patches are specified in the attribute then the patch code will be skipped.
