### PR TITLE
fix normalize_hostname for hostgroups

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -183,6 +183,7 @@ if nagios_bags.bag_list.include?('nagios_hostgroups')
       end
     end
     hostgroup_nodes[hg['hostgroup_name']] = temp_hostgroup_array.join(',')
+    hostgroup_nodes[hg['hostgroup_name']].downcase! if node['nagios']['server']['normalize_hostname']
   end
 end
 


### PR DESCRIPTION
normalize_hostname is currently broken

Hostnames are downcased in hosts.cfg.erb but not in the hostsgroup definitions. This patch fixes that by extending the normalize_hostname support to hostgroups.
