### PR TITLE
apache_site provider expects the named resource to be the filename

### DIFF
--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -25,7 +25,7 @@ apache_site '000-default' do
   enable false
 end
 
-template "#{node['apache']['dir']}/sites-available/#{node['nagios']['server']['vname']}.conf" do
+template "#{node['apache']['dir']}/sites-available/#{node['nagios']['server']['vname']}" do
   source 'apache2.conf.erb'
   mode '0644'
   variables(


### PR DESCRIPTION
The apache_site provider expects the filename in enabled-sites to match the resource name.  the template in this cookbook was xxx.conf and calling apache_stie xxx.  This quick PR fixes this.
