### PR TITLE
use cgi-bin attribute in configure flags for source install

### DIFF
--- a/recipes/server_source.rb
+++ b/recipes/server_source.rb
@@ -96,7 +96,7 @@ bash 'compile-nagios' do
     ./configure --prefix=/usr \
         --mandir=/usr/share/man \
         --bindir=/usr/sbin \
-        --sbindir=/usr/lib/cgi-bin/#{node['nagios']['server']['vname']} \
+        --sbindir=#{node['nagios']['cgi-bin']} \
         --datadir=#{node['nagios']['docroot']} \
         --sysconfdir=#{node['nagios']['conf_dir']} \
         --infodir=/usr/share/info \


### PR DESCRIPTION
--sbindir is partially hardcoded.  Changed to use the cgi-bin attribute
