### PR TITLE
Make yum-epel recipe optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Attributes
 * `node['nagios']['exclude_tag_host']` - If set, hosts tagged with this value will be excluded from nagios monitoring.  Defaults to ''
 
 * `node['nagios']['server']['install_method']` - whether to install from package or source. Default chosen by platform based on known packages available for Nagios: debian/ubuntu 'package', redhat/centos/fedora/scientific: source
+* `node['nagios']['server']['install_yum-epel']` - whether to install the EPEL repo or not (only applies to RHEL platform family). The default value is `true`. Set this to `false` if you do not wish to install the EPEL RPM; in this scenario you will need to make the relevant packages available via another method e.g. local repo, or install from source.
 * `node['nagios']['server']['service_name']` - name of the service used for Nagios, default chosen by platform, debian/ubuntu "nagios3", redhat family "nagios", all others, "nagios"
 * `node['nagios']['home']` - Nagios main home directory, default "/usr/lib/nagios3"
 * `node['nagios']['conf_dir']` - location where main Nagios config lives, default "/etc/nagios3"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -126,6 +126,7 @@ default['nagios']['server']['patches']  = []
 case node['platform_family']
 when 'rhel', 'fedora'
   default['nagios']['server']['packages'] = %w(nagios nagios-plugins-nrpe)
+  default['nagios']['install_epel'] = true
 else
   default['nagios']['server']['packages'] = %w(nagios3 nagios-nrpe-plugin nagios-images)
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -126,7 +126,7 @@ default['nagios']['server']['patches']  = []
 case node['platform_family']
 when 'rhel', 'fedora'
   default['nagios']['server']['packages'] = %w(nagios nagios-plugins-nrpe)
-  default['nagios']['install_epel'] = true
+  default['nagios']['server']['install_yum-epel'] = true
 else
   default['nagios']['server']['packages'] = %w(nagios3 nagios-nrpe-plugin nagios-images)
 end

--- a/recipes/server_package.rb
+++ b/recipes/server_package.rb
@@ -21,7 +21,7 @@
 
 case node['platform_family']
 when 'rhel'
-  include_recipe 'yum-epel'
+  include_recipe 'yum-epel' if node['nagios']['install_epel']
 when 'debian'
   # Nagios package requires to enter the admin password
   # We generate it randomly as it's overwritten later in the config templates

--- a/recipes/server_package.rb
+++ b/recipes/server_package.rb
@@ -21,7 +21,7 @@
 
 case node['platform_family']
 when 'rhel'
-  include_recipe 'yum-epel' if node['nagios']['install_epel']
+  include_recipe 'yum-epel' if node['nagios']['server']['install_yum-epel']
 when 'debian'
   # Nagios package requires to enter the admin password
   # We generate it randomly as it's overwritten later in the config templates


### PR DESCRIPTION
Hi,

Some organisations will have an local copy of the EPEL repo or may use a custom repo with only packages they require. In this case we can provide the option below to skip the include_recipe 'yum-epel' based on user preference. Default behaviour remains the same.

Regards,

Peter
