### PR TITLE
Always allow empty hostgroup assignment

### DIFF
--- a/templates/default/nagios.cfg.erb
+++ b/templates/default/nagios.cfg.erb
@@ -130,7 +130,7 @@ service_freshness_check_interval=60
 check_host_freshness=0
 host_freshness_check_interval=60
 additional_freshness_latency=15
-<% if node['nagios']['server']['install_method'] == 'source' -%>allow_empty_hostgroup_assignment=1<% end -%>
+allow_empty_hostgroup_assignment=1
 
 enable_flap_detection=1
 low_service_flap_threshold=5.0


### PR DESCRIPTION
Hi,

The option to `allow_empty_hostgroup_assignment` is enabled only if `install_method==source`. The two do not appear to be related in any logical way and not setting this value can cause a Nagios config check failure while using `install_method==package`.

This appears to have been an oversight as far as I can tell, so I believe it should always be enabled by default.

Regards,

Peter
