### PR TITLE
Only allow_empty_hostgroup_assignment for Nagios versions >= 3.4.0

### DIFF
--- a/templates/default/nagios.cfg.erb
+++ b/templates/default/nagios.cfg.erb
@@ -130,7 +130,12 @@ service_freshness_check_interval=60
 check_host_freshness=0
 host_freshness_check_interval=60
 additional_freshness_latency=15
+<% if node['nagios']['server']['install_method'] == 'source' ||
+      (node['platform_family'] == 'debian' && node['platform_version'].to_i >= 7) ||
+      (node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 6) ||
+      (node['platform_family'] == 'ubuntu' && node['platform_version'].to_f >= 14.04) -%>
 allow_empty_hostgroup_assignment=1
+<% end -%>
 
 enable_flap_detection=1
 low_service_flap_threshold=5.0


### PR DESCRIPTION
Following on from pull request #337, we need to only provide `allow_empty_hostgroup_assignment` for versions of [Nagios >= 3.4.0](http://www.nagios.org/projects/nagioscore/history/core-3x) which is when this option was introduced.

The presence of this option in versions <3.4.0 will cause a Nagios config check error.
