### PR TITLE
[apache.rb] ensure we aren't using a threaded mpm

### DIFF
--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -20,6 +20,7 @@ include_recipe 'apache2'
 include_recipe 'apache2::mod_rewrite'
 include_recipe 'apache2::mod_php5'
 include_recipe 'apache2::mod_ssl' if node['nagios']['enable_ssl']
+include_recipe 'apache2::mpm_prefork' # mod_php5 is not threadsafe as packaged
 
 apache_site '000-default' do
   enable false


### PR DESCRIPTION
closes https://github.com/tas50/nagios/issues/327

`mpm_prefork` is the lowest common denominator that will work the most places.

This _could_ be an attribute, but I don't really want to duplicate the logic they have in the apache2 cookbook to figure out the "best" mpm to choose. 

A compromise could be to default it to prefork and let people change the attribute as they see fit, but I wasn't entirely sure that was needed.
