### PR TITLE
Add ScriptAlias for our happy green checkmark.

### DIFF
--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -18,6 +18,7 @@
   Alias /stylesheets /etc/<%= node['nagios']['server']['vname'] %>/stylesheets
 <% end -%>
   ScriptAlias <%= node['nagios']['cgi-path'] %> <%= node['nagios']['cgi-bin'] %>
+  ScriptAlias /cgi-bin/statusjson.cgi <%= node['nagios']['cgi-bin'] %>/statusjson.cgi
   Alias /<%= node['nagios']['server']['vname'] %> <%= node['nagios']['docroot'] %>
 
   <Directory "<%= node['nagios']['cgi-bin'] %>">


### PR DESCRIPTION
It appears /cgi-bin/jsonstatus.cgi is hard coded, make it work.

```
$ grep -r "getCoreStatus" .
./html/main.php:        getCoreStatus();
./html/main.php:    function getCoreStatus() {
```

```
$ sudo grep -r "main.php" .
./html/index.php:$url = 'main.php';
./html/side.php:            <li><a href="main.php" target="<?php echo $link_target;?>">Home</a></li>
./update-version:perl -i -p -e "s/this_year = '.*';/this_year = '$YEAR';/;" html/main.php
./update-version:perl -i -p -e "s/releasedate\">.*<\//releasedate\">$LONGDATE<\//;" html/main.php
./update-version:perl -i -p -e "s/this_version = '.*';/this_version = '$newversion';/;" html/main.php
```
