### PR TITLE
Added alias scaffold for missing update_dependency_members method

### DIFF
--- a/libraries/base.rb
+++ b/libraries/base.rb
@@ -279,5 +279,6 @@ class Nagios
         n.push(self) if remote
       end
     end
+    alias_method :update_dependency_members, :update_members
   end
 end

--- a/libraries/base.rb
+++ b/libraries/base.rb
@@ -279,6 +279,12 @@ class Nagios
         n.push(self) if remote
       end
     end
-    alias_method :update_dependency_members, :update_members
+
+    def update_dependency_members(hash, option, object)
+      return if blank?(hash) || hash[option].nil?
+      get_members(hash[option]).each do |member|
+        push_dependency(Nagios.instance.find(object.new(member)))
+      end
+    end
   end
 end

--- a/libraries/servicedependency.rb
+++ b/libraries/servicedependency.rb
@@ -151,6 +151,7 @@ class Nagios
         'dependent_host_name'           => 'dependent_host_name',
         'dependent_hostgroup_name'      => 'dependent_hostgroup_name',
         'dependent_servicegroup_name'   => 'dependent_servicegroup_name',
+        'service_description'           => 'service_description',
         'servicegroup_name'             => 'servicegroup_name',
         'dependent_service_description' => 'dependent_service_description',
         'host_name'                     => 'host_name',

--- a/recipes/_load_databag_config.rb
+++ b/recipes/_load_databag_config.rb
@@ -74,7 +74,8 @@ end
 
 servicedependencies = nagios_bags.get(node['nagios']['servicedependencies_databag'])
 servicedependencies.each do |item|
-  nagios_servicedependency item['id'] do
+  name = item['service_description'] || item['id']
+  nagios_servicedependency name do
     options item
   end
 end


### PR DESCRIPTION
My team was recently updating our Nagios cookbook only to find that it was failing on a NoMethodError for method _update_dependency_members_. Indeed, _update_members_ is defined, but _update_dependency_members_ didn't seem to be.

I didn't see an outright reason for the additional method as the hashes appeared to merge the same either way, but didn't want to clear it out in case it was there for some unspecified edge case or intended future use. An alias seemed to be the best middle ground until a proper solution could be determined.
