### PR TITLE
Update servicegroup.rb

### DIFF
--- a/libraries/servicegroup.rb
+++ b/libraries/servicegroup.rb
@@ -66,6 +66,10 @@ class Nagios
       end
     end
 
+    def self.create(name)
+      Nagios.instance.find(Nagios::Servicegroup.new(name))
+    end
+
     def servicegroup_members
       @servicegroup_members.values.map(&:id).sort.join(',')
     end


### PR DESCRIPTION
Fixing the undefined method `create' for Nagios::Servicegroup:Class in #347
