### PR TITLE
Fixes #352 - Incorrect usage of platform_family vs. platform

### DIFF
--- a/templates/default/nagios.cfg.erb
+++ b/templates/default/nagios.cfg.erb
@@ -131,9 +131,9 @@ check_host_freshness=0
 host_freshness_check_interval=60
 additional_freshness_latency=15
 <% if node['nagios']['server']['install_method'] == 'source' ||
-      (node['platform_family'] == 'debian' && node['platform_version'].to_i >= 7) ||
       (node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 6) ||
-      (node['platform_family'] == 'ubuntu' && node['platform_version'].to_f >= 14.04) -%>
+      (node['platform'] == 'debian' && node['platform_version'].to_i >= 7) ||
+      (node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 14.04) -%>
 allow_empty_hostgroup_assignment=1
 <% end -%>
 


### PR DESCRIPTION
The `platform` attribute should have been used for the ubuntu/debian logic instead of the `platform_family` attribute (as both return the value `platform_family=debian`).
