### PR TITLE
Replace Class-type checking with Duck-typing

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -78,6 +78,9 @@ suites:
    - recipe[nagios::default]
    - recipe[nrpe::default]
    - role[monitoring]
+   attributes:
+     nagios:
+       notes: 'configured via chef attributes'
  - name: server_source
    run_list:
    - recipe[nagios::default]
@@ -85,8 +88,9 @@ suites:
    - role[monitoring]
    attributes:
      nagios:
-       server:
-         install_method: 'source'
+         notes: 'configured via chef attributes'
+         server:
+           install_method: 'source'
 data_bags_path: test/data_bags
 roles_path: test/roles
 

--- a/libraries/base.rb
+++ b/libraries/base.rb
@@ -264,11 +264,7 @@ class Nagios
 
     def update_options(hash)
       return nil if blank?(hash)
-      # We can only merge hash or databagitem's, so lets check for them.
-      case hash
-      when Hash, Chef::DataBagItem
-        update_hash_options(hash)
-      end
+      update_hash_options(hash) if hash.respond_to?('each_pair')
     end
 
     def update_hash_options(hash)

--- a/test/integration/server/serverspec/nagios_config_spec.rb
+++ b/test/integration/server/serverspec/nagios_config_spec.rb
@@ -35,6 +35,7 @@ describe 'Nagios Configuration' do
   end
 
   file_hosts = []
+  file_hosts << 'notes[ \t]+configured via chef attributes'
   file_hosts << 'host_name[ \t]+host_a'
   file_hosts << 'host_name[ \t]+host_b'
   file_hosts << 'host_name[ \t]+' + `hostname`.split('.').first


### PR DESCRIPTION
Importing object properties requires a Hash or DataBag.
Importing directly from a Chef node result in a ImmutableMash, some imports result in a Mash or ImmutableHash. This resulted in importing directly (from a) Chef node did not really import.

Main thing is that the imported object only needs to act like a Hash.
