### PR TITLE
Set (custom) hostname via attribute node[‘nagios’][‘host_name’]

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -78,9 +78,6 @@ suites:
    - recipe[nagios::default]
    - recipe[nrpe::default]
    - role[monitoring]
-   attributes:
-     nagios:
-       notes: 'configured via chef attributes'
  - name: server_source
    run_list:
    - recipe[nagios::default]
@@ -88,9 +85,8 @@ suites:
    - role[monitoring]
    attributes:
      nagios:
-         notes: 'configured via chef attributes'
-         server:
-           install_method: 'source'
+       server:
+         install_method: 'source'
 data_bags_path: test/data_bags
 roles_path: test/roles
 

--- a/libraries/nagios.rb
+++ b/libraries/nagios.rb
@@ -271,9 +271,10 @@ class Nagios
   end
 
   def get_hostname(obj)
+    return obj['nagios']['host_name'] unless blank?(obj['nagios']) || blank?(obj['nagios']['host_name'])
     return obj[@host_name_attribute] unless blank?(obj[@host_name_attribute])
     return obj['hostname'] unless blank?(obj['hostname'])
-    return obj['name'] unless blank?(obj['name'])
+    return obj.name unless blank?(obj.name)
     nil
   end
 

--- a/recipes/_load_default_config.rb
+++ b/recipes/_load_default_config.rb
@@ -36,6 +36,8 @@ if nodes.empty?
   nodes << node
 end
 
+Nagios.instance.host_name_attribute = node['nagios']['host_name_attribute'] 
+
 # Pushing current node to prevent empty hosts.cfg
 Nagios.instance.push(node)
 
@@ -164,7 +166,7 @@ nagios_host 'server' do
 end
 
 # Defaut host template
-Nagios.instance.default_host = 'server'
+Nagios.instance.default_host = node['nagios']['host_template']
 
 # Users
 # use the users_helper.rb library to build arrays of users and contacts

--- a/recipes/_load_default_config.rb
+++ b/recipes/_load_default_config.rb
@@ -36,7 +36,7 @@ if nodes.empty?
   nodes << node
 end
 
-Nagios.instance.host_name_attribute = node['nagios']['host_name_attribute'] 
+Nagios.instance.host_name_attribute = node['nagios']['host_name_attribute']
 
 # Pushing current node to prevent empty hosts.cfg
 Nagios.instance.push(node)

--- a/test/integration/data_bags/nagios_unmanagedhosts/host_a.json
+++ b/test/integration/data_bags/nagios_unmanagedhosts/host_a.json
@@ -1,5 +1,7 @@
 {
   "id": "host_a",
+  "host_name": "host_a_alt",
+  "notes": "via chef attribute node.nagios.host_name from databag",
   "alias": "Host A Alias Name",
   "display_name": "Host A Display Name",
   "hostgroups": "hostgroup_a"

--- a/test/integration/nodes/chefnode_a.json
+++ b/test/integration/nodes/chefnode_a.json
@@ -1,0 +1,8 @@
+{
+  "normal": {
+    "nagios": {
+      "notes": "notes configured via chef node attributes"
+    }
+   },
+  "run_list": []
+}

--- a/test/integration/nodes/chefnode_b.json
+++ b/test/integration/nodes/chefnode_b.json
@@ -1,0 +1,9 @@
+{
+  "normal": {
+    "nagios": {
+      "host_name": "chefnode_b_alt",
+      "notes": "hostname via chef attribute node.nagios.host_name"
+    }
+   },
+  "run_list": []
+}

--- a/test/integration/nodes/chefnode_c.json
+++ b/test/integration/nodes/chefnode_c.json
@@ -1,0 +1,10 @@
+{
+  "normal": {
+    "custom_host_name_attribute": "chefnode_c",
+    "nagios": {
+      "host_name": "chefnode_c_alt",
+      "notes": "hostname via chef attribute node.nagios.host_name, despite presence custom_host_name_attribute"
+    }
+   },
+  "run_list": []
+}

--- a/test/integration/nodes/chefnode_d.json
+++ b/test/integration/nodes/chefnode_d.json
@@ -1,0 +1,9 @@
+{
+  "normal": {
+    "custom_host_name_attribute": "chefnode_d_alt",
+    "nagios": {
+      "notes": "hostname via chef attribute node.custom_host_name_attribute"
+    }
+   },
+  "run_list": []
+}

--- a/test/integration/roles/monitoring.json
+++ b/test/integration/roles/monitoring.json
@@ -1,4 +1,9 @@
 {
   "id": "monitoring",
-  "name": "monitoring"
+  "name": "monitoring",
+  "override_attributes": {
+    "nagios": {
+      "host_name_attribute": "custom_host_name_attribute"
+    }
+  }
 }

--- a/test/integration/server/serverspec/nagios_config_spec.rb
+++ b/test/integration/server/serverspec/nagios_config_spec.rb
@@ -35,10 +35,15 @@ describe 'Nagios Configuration' do
   end
 
   file_hosts = []
-  file_hosts << 'notes[ \t]+configured via chef attributes'
-  file_hosts << 'host_name[ \t]+host_a'
+  file_hosts << 'host_name[ \t]+host_a_alt'
   file_hosts << 'host_name[ \t]+host_b'
   file_hosts << 'host_name[ \t]+' + `hostname`.split('.').first
+  file_hosts << 'host_name[ \t]+chefnode_a'
+  file_hosts << 'notes[ \t]+configured via chef node attributes'
+  file_hosts << 'host_name[ \t]+chefnode_b_alt'
+  file_hosts << 'host_name[ \t]+chefnode_c_alt'
+  file_hosts << 'host_name[ \t]+chefnode_d_alt'
+  
 
   file_hosts.each do |line|
     describe file('/etc/nagios/conf.d/hosts.cfg') do
@@ -75,7 +80,7 @@ describe 'Nagios Configuration' do
   end
 
   file_servicegroups = []
-  file_servicegroups << 'servicegroup_name.*servicegroup_a\n\s*members.*host_a,service_a,host_a,service_b,host_b,service_b,host_b,service_c'
+  file_servicegroups << 'servicegroup_name.*servicegroup_a\n\s*members.*host_a_alt,service_a,host_a_alt,service_b,host_b,service_b,host_b,service_c'
   file_servicegroups << 'servicegroup_name.*servicegroup_b\n\s*members.*host_b,service_c'
 
   file_servicegroups.each do |line|

--- a/test/integration/server/serverspec/nagios_config_spec.rb
+++ b/test/integration/server/serverspec/nagios_config_spec.rb
@@ -43,7 +43,6 @@ describe 'Nagios Configuration' do
   file_hosts << 'host_name[ \t]+chefnode_b_alt'
   file_hosts << 'host_name[ \t]+chefnode_c_alt'
   file_hosts << 'host_name[ \t]+chefnode_d_alt'
-  
 
   file_hosts.each do |line|
     describe file('/etc/nagios/conf.d/hosts.cfg') do


### PR DESCRIPTION
just like all other attributes of the nagios host.
When set, overrides ‘host_name_attribute’.

Added missing link with the attribute node['nagios']['host_name_attribute']
