### PR TITLE
Missing stylesheet on Ubuntu 14.04.

### DIFF
--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -16,6 +16,7 @@
 
 <% if node.platform_family == 'debian' && node['nagios']['server']['install_method'] == 'package'-%>
   Alias /stylesheets /etc/<%= node['nagios']['server']['vname'] %>/stylesheets
+  Alias /nagios3/stylesheets /etc/<%= node['nagios']['server']['vname'] %>/stylesheets
 <% end -%>
   ScriptAlias <%= node['nagios']['cgi-path'] %> <%= node['nagios']['cgi-bin'] %>
   Alias /<%= node['nagios']['server']['vname'] %> <%= node['nagios']['docroot'] %>


### PR DESCRIPTION
When using Nagios, main page look for stylesheets on /stylesheets but
hosts and services frames look for styles on /nagios3/stylesheets.
