### PR TITLE
Set host_name_attribute when using _load_databag_config

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'tsmith84@gmail.com'
 license           'Apache 2.0'
 description       'Installs and configures Nagios server'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '7.0.9'
+version           '7.0.10'
 
 recipe 'default', 'Installs Nagios server.'
 recipe 'nagios::pagerduty', 'Integrates contacts w/ PagerDuty API'

--- a/recipes/_load_databag_config.rb
+++ b/recipes/_load_databag_config.rb
@@ -20,6 +20,8 @@
 # Loading all databag information
 nagios_bags = NagiosDataBags.new
 
+Nagios.instance.host_name_attribute = node['nagios']['host_name_attribute']
+
 hostgroups = nagios_bags.get(node['nagios']['hostgroups_databag'])
 hostgroups.each do |group|
   next if group['search_query'].nil?


### PR DESCRIPTION
When using _load_databag_config recipe, host_name_attribute was being set correctly, but not when using _load_default_config. This feature was added in version 7.0.9.
