### PR TITLE
Hostname attribute is set before _load_databag_config.

### DIFF
--- a/recipes/_load_default_config.rb
+++ b/recipes/_load_default_config.rb
@@ -36,8 +36,6 @@ if nodes.empty?
   nodes << node
 end
 
-Nagios.instance.host_name_attribute = node['nagios']['host_name_attribute']
-
 # Pushing current node to prevent empty hosts.cfg
 Nagios.instance.push(node)
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -104,6 +104,8 @@ unless node['nagios'].nil?
   end
 end
 
+Nagios.instance.host_name_attribute = node['nagios']['host_name_attribute']
+
 # loading all databag configurations
 if node['nagios']['server']['load_databag_config']
   include_recipe 'nagios::_load_databag_config'


### PR DESCRIPTION
When using _load_default_config recipe, host_name_attribute was being
set correctly, but not when using _load_databag_config.
