### PR TITLE
AuthzLDAPAuthoritative was removed in Apache 2.4.

### DIFF
--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -63,7 +63,7 @@
     <% unless node['nagios']['ldap_bind_dn'].nil? -%>AuthLDAPBindDN "<%= node['nagios']['ldap_bind_dn'] %>" <% end -%>
     <% unless node['nagios']['ldap_bind_password'].nil? -%>AuthLDAPBindPassword "<%= node['nagios']['ldap_bind_password'] %>"<% end -%>
     AuthLDAPURL "<%= node['nagios']['ldap_url'] %>"
-    AuthzLDAPAuthoritative <%= node['nagios']['ldap_authoritative'] %>
+    <% if node['apache']['version'] < "2.4" %>AuthzLDAPAuthoritative <%= node['nagios']['ldap_authoritative'] %><% end %>
     require valid-user
   </Location>
 <% else -%>


### PR DESCRIPTION
When using LDAP, the template was always including
AuthzLDAPAuthoritative directive, which makes Apache 2.4 to fail.

http://httpd.apache.org/docs/2.4/upgrading.html#run-time

I've tested this on Ubuntu 14.04.2 and it works OK.
