### PR TITLE
allow custom apache auth requirement

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -133,6 +133,7 @@ default['nagios']['default_contact_groups']      = %w(admins)
 default['nagios']['sysadmin_email']              = 'root@localhost'
 default['nagios']['sysadmin_sms_email']          = 'root@localhost'
 default['nagios']['server_auth_method']          = 'htauth'
+default['nagios']['server_auth_require']         = 'valid-user'
 default['nagios']['users_databag']               = 'users'
 default['nagios']['users_databag_group']         = 'sysadmin'
 default['nagios']['services_databag']            = 'nagios_services'

--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -53,7 +53,7 @@
 
   <Location />
     AuthType CAS
-    require valid-user
+    require <%= node['nagios']['server_auth_require'] %>
   </Location>
 <% when "ldap" -%>
   <Location />
@@ -64,14 +64,14 @@
     <% unless node['nagios']['ldap_bind_password'].nil? -%>AuthLDAPBindPassword "<%= node['nagios']['ldap_bind_password'] %>"<% end -%>
     AuthLDAPURL "<%= node['nagios']['ldap_url'] %>"
     <% if node['apache']['version'] < "2.4" %>AuthzLDAPAuthoritative <%= node['nagios']['ldap_authoritative'] %><% end %>
-    require valid-user
+    require <%= node['nagios']['server_auth_require'] %>
   </Location>
 <% else -%>
   <Location />
     AuthName "Nagios Server"
     AuthType Basic
     AuthUserFile "<%= node['nagios']['conf_dir'] %>/htpasswd.users"
-    require valid-user
+    require <%= node['nagios']['server_auth_require'] %>
   </Location>
 <% end -%>
 


### PR DESCRIPTION
I need the option to create my own authentication requirement (ldap-group, etc) in the apache config.

I've added a new default, so this change will not break code for previous versions.
