### PR TITLE
Mattse activate check in environment

### DIFF
--- a/recipes/_load_databag_config.rb
+++ b/recipes/_load_databag_config.rb
@@ -40,7 +40,7 @@ end
 
 services = nagios_bags.get(node['nagios']['services_databag'])
 services.each do |item|
-  if item['activate_check_in_environment'].nil? || item['activate_check_in_environment'].include? node.chef_environment
+  if item['activate_check_in_environment'].nil? || item['activate_check_in_environment'].include?(node.chef_environment)
     name = item['service_description'] || item['id']
     command_name = name.downcase.start_with?('check_') ? name.downcase : 'check_' + name.downcase
     service_name = name.downcase.start_with?('check_') ? name.gsub('check_', '') : name.downcase

--- a/recipes/_load_databag_config.rb
+++ b/recipes/_load_databag_config.rb
@@ -40,17 +40,19 @@ end
 
 services = nagios_bags.get(node['nagios']['services_databag'])
 services.each do |item|
-  name = item['service_description'] || item['id']
-  command_name = name.downcase.start_with?('check_') ? name.downcase : 'check_' + name.downcase
-  service_name = name.downcase.start_with?('check_') ? name.gsub('check_', '') : name.downcase
-  item['check_command'] = command_name
+  if item['activate_check_in_environment'].nil? || item['activate_check_in_environment'].include? node.chef_environment
+    name = item['service_description'] || item['id']
+    command_name = name.downcase.start_with?('check_') ? name.downcase : 'check_' + name.downcase
+    service_name = name.downcase.start_with?('check_') ? name.gsub('check_', '') : name.downcase
+    item['check_command'] = command_name
 
-  nagios_command command_name do
-    options item
-  end
+    nagios_command command_name do
+      options item
+    end
 
-  nagios_service service_name do
-    options item
+    nagios_service service_name do
+      options item
+    end
   end
 end
 


### PR DESCRIPTION
This PR adds back in the `activate_check_in_environment` functionality for [nagios services data bags](https://github.com/schubergphilis/nagios/wiki/services).  The feature was broken in master due to some change in the past, and the wiki hasn't been updated.

This changes the functionality slightly in that `activate_check_in_environment` is no longer a single field, but an array of strings.  So any nagios service that has this field, will only be activated if the chef environment the Nagios server is in matches one of the strings in this array.  If `activate_check_in_environment` is not specified, the nagios service will always apply.
