### PR TITLE
Fix inheritance options

### DIFF
--- a/libraries/base.rb
+++ b/libraries/base.rb
@@ -26,6 +26,10 @@ class Nagios
                   :name,
                   :use
 
+    def initialize
+      @modifiers = {}
+    end
+
     def merge!(obj)
       merge_members(obj)
       merge_attributes(obj)
@@ -171,7 +175,7 @@ class Nagios
       longest = get_longest_option(options)
       options.each do |k, v|
         k = k.to_s
-        v = v.to_s
+        v = ( @modifiers[k] || '' ) + v.to_s
         diff = longest - k.length
         r.push(k.rjust(k.length + 2) + v.rjust(v.length + diff + 2))
       end
@@ -274,6 +278,10 @@ class Nagios
     def update_hash_options(hash)
       hash.each do |k, v|
         push(Nagios::CustomOption.new(k.upcase, v)) if k.start_with?('_')
+        if v.is_a? String
+          @modifiers[k] = v[/^[+!]/]
+          v = v.gsub /^[+!]/, ''
+        end
         m = k + '='
         send(m, v) if self.respond_to?(m)
       end
@@ -282,7 +290,7 @@ class Nagios
     def update_members(hash, option, object, remote = false)
       return if blank?(hash) || hash[option].nil?
       get_members(hash[option], object).each do |member|
-        n = Nagios.instance.find(object.new(member))
+        n = Nagios.instance.find(object.new(member.gsub /^[+!]/, ''))
         push(n)
         n.push(self) if remote
       end

--- a/libraries/base.rb
+++ b/libraries/base.rb
@@ -231,7 +231,11 @@ class Nagios
     end
 
     def push_object(obj, hash)
-      if hash[obj.to_s].nil?
+      return if hash.key?('null')
+      if obj.to_s == 'null'
+        hash.delete_if { |_k, _v| true }
+        hash[obj.to_s] = obj
+      elsif hash[obj.to_s].nil?
         hash[obj.to_s] = obj
       else
         Chef::Log.debug("Nagios debug: #{self.class} already contains #{obj.class} with name: #{obj}")

--- a/libraries/base.rb
+++ b/libraries/base.rb
@@ -233,12 +233,20 @@ class Nagios
     def push_object(obj, hash)
       return if hash.key?('null')
       if obj.to_s == 'null'
-        hash.delete_if { |_k, _v| true }
+        hash.values { |object| pop(object) }
         hash[obj.to_s] = obj
       elsif hash[obj.to_s].nil?
         hash[obj.to_s] = obj
       else
         Chef::Log.debug("Nagios debug: #{self.class} already contains #{obj.class} with name: #{obj}")
+      end
+    end
+
+    def pop_object(obj, hash)
+      if hash.key?(obj.to_s)
+        hash.delete(obj.to_s)
+      else
+        Chef::Log.debug("Nagios debug: #{self.class} does not contain #{obj.class} with name: #{obj}")
       end
     end
 

--- a/libraries/base.rb
+++ b/libraries/base.rb
@@ -175,7 +175,7 @@ class Nagios
       longest = get_longest_option(options)
       options.each do |k, v|
         k = k.to_s
-        v = ( @modifiers[k] || '' ) + v.to_s
+        v = (@modifiers[k] || '') + v.to_s
         diff = longest - k.length
         r.push(k.rjust(k.length + 2) + v.rjust(v.length + diff + 2))
       end
@@ -280,7 +280,7 @@ class Nagios
         push(Nagios::CustomOption.new(k.upcase, v)) if k.start_with?('_')
         if v.is_a? String
           @modifiers[k] = v[/^[+!]/]
-          v = v.gsub /^[+!]/, ''
+          v = v.gsub(/^[+!]/, '')
         end
         m = k + '='
         send(m, v) if self.respond_to?(m)
@@ -290,7 +290,7 @@ class Nagios
     def update_members(hash, option, object, remote = false)
       return if blank?(hash) || hash[option].nil?
       get_members(hash[option], object).each do |member|
-        n = Nagios.instance.find(object.new(member.gsub /^[+!]/, ''))
+        n = Nagios.instance.find(object.new(member.gsub(/^[+!]/, '')))
         push(n)
         n.push(self) if remote
       end

--- a/libraries/command.rb
+++ b/libraries/command.rb
@@ -33,6 +33,7 @@ class Nagios
       cmd = command_name.split('!')
       @command_name = cmd.shift
       @timeout = nil
+      super()
     end
 
     def definition

--- a/libraries/contact.rb
+++ b/libraries/contact.rb
@@ -60,7 +60,7 @@ class Nagios
     end
 
     def definition
-      return if name == 'null'
+      return if contact_name == 'null'
       if email.nil? && name.nil? && pager.nil?
         "# Skipping #{contact_name} because missing email/pager."
       else

--- a/libraries/contact.rb
+++ b/libraries/contact.rb
@@ -52,6 +52,7 @@ class Nagios
       @host_notification_commands = []
       @service_notification_commands = []
       @custom_options = {}
+      super()
     end
 
     def contactgroups_list

--- a/libraries/contact.rb
+++ b/libraries/contact.rb
@@ -103,6 +103,22 @@ class Nagios
       end
     end
 
+    # rubocop:disable MethodLength
+    def pop(obj)
+      case obj
+      when Nagios::Contactgroup
+        pop_object(obj, @contactgroups)
+        pop(self, obj)
+      when Nagios::Timeperiod
+        @host_notification_period = nil if obj == @host_notification_period
+        @service_notification_period = nil if obj == @service_notification_period
+      when Nagios::CustomOption
+        pop_object(obj, @custom_options)
+        pop(self, obj)
+      end
+    end
+    # rubocop:enable MethodLength
+
     def service_notification_commands
       get_commands(@service_notification_commands)
     end

--- a/libraries/contact.rb
+++ b/libraries/contact.rb
@@ -59,6 +59,7 @@ class Nagios
     end
 
     def definition
+      return if name == 'null'
       if email.nil? && name.nil? && pager.nil?
         "# Skipping #{contact_name} because missing email/pager."
       else

--- a/libraries/contactgroup.rb
+++ b/libraries/contactgroup.rb
@@ -46,6 +46,7 @@ class Nagios
     end
 
     def definition
+      return if contactgroup_name == '*' || contactgroup_name == 'null'
       get_definition(configured_options, 'contactgroup')
     end
 

--- a/libraries/contactgroup.rb
+++ b/libraries/contactgroup.rb
@@ -35,6 +35,7 @@ class Nagios
       @contactgroup_name = contactgroup_name
       @members = {}
       @contactgroup_members = {}
+      super()
     end
 
     def contactgroup_members_list

--- a/libraries/contactgroup.rb
+++ b/libraries/contactgroup.rb
@@ -70,6 +70,17 @@ class Nagios
       end
     end
 
+    def pop(obj)
+      case obj
+      when Nagios::Contact
+        pop_object(obj, @members)
+        pop(self, obj)
+      when Nagios::Contactgroup
+        pop_object(obj, @contactgroup_members)
+        pop(self, obj)
+      end
+    end
+
     def to_s
       contactgroup_name
     end

--- a/libraries/host.rb
+++ b/libraries/host.rb
@@ -82,6 +82,7 @@ class Nagios
       @check_period = nil
       @notification_period = nil
       @custom_options = {}
+      super()
     end
 
     def check_period

--- a/libraries/host.rb
+++ b/libraries/host.rb
@@ -109,6 +109,7 @@ class Nagios
     end
 
     def definition
+      return if host_name == '*' || host_name == 'null'
       configured = configured_options
       custom_options.each { |_, v| configured[v.to_s] = v.value }
       get_definition(configured, 'host')

--- a/libraries/hostdependency.rb
+++ b/libraries/hostdependency.rb
@@ -19,6 +19,7 @@
 
 require_relative 'base'
 
+# rubocop:disable ClassLength
 class Nagios
   #
   # This class holds all methods with regard to hostdependency options,
@@ -84,12 +85,36 @@ class Nagios
       end
     end
 
+    def pop(obj)
+      case obj
+      when Nagios::Host
+        pop_object(obj, @host_name)
+        pop(self, obj)
+      when Nagios::Hostgroup
+        pop_object(obj, @hostgroup_name)
+        pop(self, obj)
+      when Nagios::Timeperiod
+        @dependency_period = nil if @dependency_period == obj
+      end
+    end
+
     def push_dependency(obj)
       case obj
       when Nagios::Host
         push_object(obj, @dependent_host_name)
       when Nagios::Hostgroup
         push_object(obj, @dependent_hostgroup_name)
+      end
+    end
+
+    def pop_dependency(obj)
+      case obj
+      when Nagios::Host
+        pop_object(obj, @dependent_host_name)
+        pop(self, obj)
+      when Nagios::Hostgroup
+        pop_object(obj, @dependent_hostgroup_name)
+        pop(self, obj)
       end
     end
 
@@ -144,3 +169,4 @@ class Nagios
     end
   end
 end
+# rubocop:enable ClassLength

--- a/libraries/hostdependency.rb
+++ b/libraries/hostdependency.rb
@@ -42,6 +42,7 @@ class Nagios
       @hostgroup_name           = {}
       @dependent_host_name      = {}
       @dependent_hostgroup_name = {}
+      super()
     end
 
     def definition

--- a/libraries/hostescalation.rb
+++ b/libraries/hostescalation.rb
@@ -19,6 +19,7 @@
 
 require_relative 'base'
 
+# rubocop:disable ClassLength
 class Nagios
   #
   # This class holds all methods with regard to hostescalation options,
@@ -89,6 +90,25 @@ class Nagios
         @escalation_period = obj
       end
     end
+
+    def pop(obj)
+      case obj
+      when Nagios::Host
+        pop_object(obj, @host_name)
+        pop(self, obj)
+      when Nagios::Hostgroup
+        pop_object(obj, @hostgroup_name)
+        pop(self, obj)
+      when Nagios::Contact
+        pop_object(obj, @contacts)
+        pop(self, obj)
+      when Nagios::Contactgroup
+        pop_object(obj, @contact_groups)
+        pop(self, obj)
+      when Nagios::Timeperiod
+        @escalation_period = nil if @escalation_period == obj
+      end
+    end
     # rubocop:enable MethodLength
 
     def to_s
@@ -144,3 +164,4 @@ class Nagios
     end
   end
 end
+# rubocop:enable ClassLength

--- a/libraries/hostescalation.rb
+++ b/libraries/hostescalation.rb
@@ -43,6 +43,7 @@ class Nagios
       @contact_groups   = {}
       @host_name        = {}
       @hostgroup_name   = {}
+      super()
     end
 
     def definition

--- a/libraries/hostgroup.rb
+++ b/libraries/hostgroup.rb
@@ -41,6 +41,7 @@ class Nagios
     end
 
     def definition
+      return if hostgroup_name == 'null'
       get_definition(configured_options, 'hostgroup')
     end
 

--- a/libraries/hostgroup.rb
+++ b/libraries/hostgroup.rb
@@ -69,6 +69,17 @@ class Nagios
       end
     end
 
+    def pop(obj)
+      case obj
+      when Nagios::Host
+        pop_object(obj, @members)
+        pop(self, obj)
+      when Nagios::Hostgroup
+        pop_object(obj, @hostgroup_members)
+        pop(self, obj)
+      end
+    end
+
     def self.create(name)
       Nagios.instance.find(Nagios::Hostgroup.new(name))
     end

--- a/libraries/hostgroup.rb
+++ b/libraries/hostgroup.rb
@@ -38,6 +38,7 @@ class Nagios
       @hostgroup_name = hostgroup_name
       @members = {}
       @hostgroup_members = {}
+      super()
     end
 
     def definition

--- a/libraries/resource.rb
+++ b/libraries/resource.rb
@@ -31,6 +31,7 @@ class Nagios
     def initialize(key, value = nil)
       @key = key
       @value = value
+      super()
     end
 
     def definition

--- a/libraries/service.rb
+++ b/libraries/service.rb
@@ -71,6 +71,7 @@ class Nagios
                   :icon_image,
                   :icon_image_alt
 
+    # rubocop:disable MethodLength
     def initialize(service_description)
       @service_description = service_description
       srv = service_description.split('!')
@@ -84,6 +85,7 @@ class Nagios
       @custom_options      = {}
       super()
     end
+    # rubocop:enable MethodLength
 
     def check_command
       if blank?(@arguments)

--- a/libraries/service.rb
+++ b/libraries/service.rb
@@ -186,6 +186,34 @@ class Nagios
         push_object(obj, @custom_options)
       end
     end
+
+    def pop(obj)
+      case obj
+      when Nagios::Servicegroup
+        pop_object(obj, @servicegroups)
+        pop(self, obj)
+      when Nagios::Hostgroup
+        pop_object(obj, @hostgroups)
+        pop(self, obj)
+      when Nagios::Host
+        pop_object(obj, @hosts)
+        pop(self, obj)
+      when Nagios::Contact
+        pop_object(obj, @contacts)
+        pop(self, obj)
+      when Nagios::Contactgroup
+        pop_object(obj, @contact_groups)
+        pop(self, obj)
+      when Nagios::Command
+        @check_command = nil if @check_command == obj
+      when Nagios::Timeperiod
+        @check_period = nil if @check_command == obj
+        @notification_period = nil if @check_command == obj
+      when Nagios::CustomOption
+        pop_object(obj, @custom_options)
+        pop(self, obj)
+      end
+    end
     # rubocop:enable MethodLength
 
     # servicegroups

--- a/libraries/service.rb
+++ b/libraries/service.rb
@@ -82,6 +82,7 @@ class Nagios
       @hostgroups          = {}
       @hosts               = {}
       @custom_options      = {}
+      super()
     end
 
     def check_command

--- a/libraries/servicedependency.rb
+++ b/libraries/servicedependency.rb
@@ -49,6 +49,7 @@ class Nagios
       @dependent_host_name         = {}
       @dependent_hostgroup_name    = {}
       @dependent_servicegroup_name = {}
+      super()
     end
 
     def definition

--- a/libraries/servicedependency.rb
+++ b/libraries/servicedependency.rb
@@ -103,6 +103,24 @@ class Nagios
       end
     end
 
+    # rubocop:disable MethodLength
+    def pop(obj)
+      case obj
+      when Nagios::Host
+        pop_object(obj, @host_name)
+        pop(self, obj)
+      when Nagios::Hostgroup
+        pop_object(obj, @hostgroup_name)
+        pop(self, obj)
+      when Nagios::Servicegroup
+        pop_object(obj, @servicegroup_name)
+        pop(self, obj)
+      when Nagios::Timeperiod
+        @dependency_period = nil if @dependency_period == obj
+      end
+    end
+    # rubocop:enable MethodLength
+
     def push_dependency(obj)
       case obj
       when Nagios::Host
@@ -111,6 +129,17 @@ class Nagios
         push_object(obj, @dependent_hostgroup_name)
       when Nagios::Servicegroup
         push_object(obj, @dependent_servicegroup_name)
+      end
+    end
+
+    def pop_dependency(obj)
+      case obj
+      when Nagios::Host
+        pop_object(obj, @dependent_host_name)
+      when Nagios::Hostgroup
+        pop_object(obj, @dependent_hostgroup_name)
+      when Nagios::Servicegroup
+        pop_object(obj, @dependent_servicegroup_name)
       end
     end
 

--- a/libraries/serviceescalation.rb
+++ b/libraries/serviceescalation.rb
@@ -103,6 +103,28 @@ class Nagios
         @escalation_period = obj
       end
     end
+
+    def pop(obj)
+      case obj
+      when Nagios::Host
+        pop_object(obj, @host_name)
+        pop(self, obj)
+      when Nagios::Hostgroup
+        pop_object(obj, @hostgroup_name)
+        pop(self, obj)
+      when Nagios::Servicegroup
+        pop_object(obj, @servicegroup_name)
+        pop(self, obj)
+      when Nagios::Contact
+        pop_object(obj, @contacts)
+        pop(self, obj)
+      when Nagios::Contactgroup
+        pop_object(obj, @contact_groups)
+        pop(self, obj)
+      when Nagios::Timeperiod
+        @escalation_period = nil if @escalation_period == obj
+      end
+    end
     # rubocop:enable MethodLength
 
     def to_s

--- a/libraries/serviceescalation.rb
+++ b/libraries/serviceescalation.rb
@@ -45,6 +45,7 @@ class Nagios
       @host_name           = {}
       @hostgroup_name      = {}
       @servicegroup_name   = {}
+      super()
     end
 
     def definition

--- a/libraries/servicegroup.rb
+++ b/libraries/servicegroup.rb
@@ -66,6 +66,17 @@ class Nagios
       end
     end
 
+    def pop(obj)
+      case obj
+      when Nagios::Service
+        pop_object(obj, @members)
+        pop(self, obj)
+      when Nagios::Servicegroup
+        pop_object(obj, @servicegroup_members)
+        pop(self, obj)
+      end
+    end
+
     def self.create(name)
       Nagios.instance.find(Nagios::Servicegroup.new(name))
     end

--- a/libraries/servicegroup.rb
+++ b/libraries/servicegroup.rb
@@ -41,6 +41,7 @@ class Nagios
     end
 
     def definition
+      return if servicegroup_name == '*' || servicegroup_name == 'null'
       get_definition(configured_options, 'servicegroup')
     end
 

--- a/libraries/servicegroup.rb
+++ b/libraries/servicegroup.rb
@@ -38,6 +38,7 @@ class Nagios
       @servicegroup_name = servicegroup_name
       @members = {}
       @servicegroup_members = {}
+      super()
     end
 
     def definition

--- a/libraries/timeperiod.rb
+++ b/libraries/timeperiod.rb
@@ -60,6 +60,7 @@ class Nagios
       @timeperiod_name = timeperiod_name
       @periods = {}
       @exclude = {}
+      super()
     end
 
     def self.create(name)

--- a/libraries/timeperiod.rb
+++ b/libraries/timeperiod.rb
@@ -67,6 +67,7 @@ class Nagios
     end
 
     def definition
+      return if timeperiod_name == 'null'
       configured = configured_options
       periods.values.each { |v| configured[v.moment] = v.period }
       get_definition(configured, 'timeperiod')

--- a/libraries/timeperiod.rb
+++ b/libraries/timeperiod.rb
@@ -100,6 +100,17 @@ class Nagios
       end
     end
 
+    def pop(obj)
+      case obj
+      when Nagios::Timeperiod
+        pop_object(obj, @exclude)
+        pop(self, obj)
+      when Nagios::Timeperiodentry
+        pop_object(obj, @periods)
+        pop(self, obj)
+      end
+    end
+
     def to_s
       timeperiod_name
     end

--- a/test/integration/data_bags/nagios_services/additive_inheritance.json
+++ b/test/integration/data_bags/nagios_services/additive_inheritance.json
@@ -1,0 +1,6 @@
+{
+  "id": "additive_inheritance",
+  "hostgroup_name": "hostgroup_a",
+  "command_line": "$USER1$/check_something...",
+  "contact_groups": "+non_admins"
+}

--- a/test/integration/data_bags/nagios_services/additive_inheritance.json
+++ b/test/integration/data_bags/nagios_services/additive_inheritance.json
@@ -2,5 +2,5 @@
   "id": "additive_inheritance",
   "hostgroup_name": "hostgroup_a",
   "command_line": "$USER1$/check_something...",
-  "contact_groups": "+non_admins"
+  "contact_groups": "+non_admins,dev"
 }

--- a/test/integration/data_bags/nagios_services/null_contact_group_service.json
+++ b/test/integration/data_bags/nagios_services/null_contact_group_service.json
@@ -1,6 +1,7 @@
 {
-  "id": "null_contact_service",
+  "id": "null_contact_group_service",
   "hostgroup_name": "all",
   "command_line": "$USER1$/check_nrpe -H $HOSTADDRESS$ -c check_something -t 20",
-  "contacts": "null"
+  "contact_groups": "null",
+  "contacts": "devs"
 }

--- a/test/integration/data_bags/nagios_services/null_contact_service.json
+++ b/test/integration/data_bags/nagios_services/null_contact_service.json
@@ -1,0 +1,7 @@
+{
+  "id": "null_contact_service",
+  "hostgroup_name": "all",
+  "command_line": "$USER1$/check_nrpe -H $HOSTADDRESS$ -c check_something -t 20",
+  "contact_groups": "null",
+  "contacts": "devs"
+}

--- a/test/integration/data_bags/nagios_services/wildcard_host_service.json
+++ b/test/integration/data_bags/nagios_services/wildcard_host_service.json
@@ -1,0 +1,5 @@
+{
+  "id": "wildcard_host_service",
+  "host_name": "*",
+  "command_line": "$USER1$/check_nrpe -H $HOSTADDRESS$ -c check_something -t 20"
+}

--- a/test/integration/server/serverspec/nagios_config_spec.rb
+++ b/test/integration/server/serverspec/nagios_config_spec.rb
@@ -56,7 +56,7 @@ describe 'Nagios Configuration' do
   file_services << 'service_description.*service_b'
   file_services << 'service_description.*service_c'
   file_services << 'check_command.*system-load!15,10,5!30,25,20'
-  file_services << 'contact_groups.*\+non_admins'
+  file_services << 'contact_groups.*\+[^ ]+non_admins'
   file_services << 'contact_groups.*null'
   file_services << 'host_name.*\*'
 
@@ -108,6 +108,7 @@ describe 'Nagios Configuration' do
   end
 
   file_contacts_exclude = []
+  file_contacts_exclude << 'contact_name.*null'
   file_contacts_exclude << 'contact_group.*null'
   file_contacts_exclude << 'contact_group.*\+non_admins'
 

--- a/test/integration/server/serverspec/nagios_config_spec.rb
+++ b/test/integration/server/serverspec/nagios_config_spec.rb
@@ -56,6 +56,9 @@ describe 'Nagios Configuration' do
   file_services << 'service_description.*service_b'
   file_services << 'service_description.*service_c'
   file_services << 'check_command.*system-load!15,10,5!30,25,20'
+  file_services << 'contact_groups.*\+non_admins'
+  file_services << 'contact_groups.*null'
+  file_services << 'host_name.*\*'
 
   file_services.each do |line|
     describe file("#{path_config_dir}/services.cfg") do
@@ -83,6 +86,7 @@ describe 'Nagios Configuration' do
   file_hosts_exclude = []
   file_hosts_exclude << 'chefnode_exclude_arr'
   file_hosts_exclude << 'chefnode_exclude_str'
+  file_hosts_exclude << 'host_name.*\*'
 
   file_hosts_exclude.each do |line|
     describe file("#{path_config_dir}/hosts.cfg") do
@@ -100,6 +104,16 @@ describe 'Nagios Configuration' do
   file_contacts.each do |line|
     describe file("#{path_config_dir}/contacts.cfg") do
       its(:content) { should match line }
+    end
+  end
+
+  file_contacts_exclude = []
+  file_contacts_exclude << 'contact_group.*null'
+  file_contacts_exclude << 'contact_group.*\+non_admins'
+
+  file_contacts_exclude.each do |line|
+    describe file("#{path_config_dir}/contacts.cfg") do
+      its(:content) { should_not match line }
     end
   end
 


### PR DESCRIPTION
I was thinking about the inheritance options, and the only way I could think about the directive modifiers was to store them and add them back in in the when they are rendered in the definition, and to skip any objects named "null" or "*".
