### PR TITLE
Adding the ability to use this resource in other cookbooks.

### DIFF
--- a/definitions/nagios_conf.rb
+++ b/definitions/nagios_conf.rb
@@ -26,6 +26,7 @@ define :nagios_conf, :variables => {}, :config_subdir => true, :source => nil do
   params[:source] ||= "#{params[:name]}.cfg.erb"
 
   template "#{conf_dir}/#{params[:name]}.cfg" do
+    cookbook params[:cookbook] if params[:cookbook]
     owner node['nagios']['user']
     group node['nagios']['group']
     source params[:source]


### PR DESCRIPTION
Basically I have a wrapper cookbook called `mycompany_nagios` because we use chef-solo and thus can't use `nagios::default`.

I want to be able to run `nagios_conf 'timeperiods'` (for example), but I want it to use the template in the nagios cookbook instead of copying it into my wrapper cookbook.

This PR allows me to use the following and have it work as expected:

``` ruby
nagios_conf 'timeperiods' do
  cookbook 'nagios'
end
```
