### PR TITLE
Add systemd support for Ubuntu 15.04

### DIFF
--- a/definitions/nagios_conf.rb
+++ b/definitions/nagios_conf.rb
@@ -32,7 +32,11 @@ define :nagios_conf, :variables => {}, :config_subdir => true, :source => nil do
     source params[:source]
     mode '0644'
     variables params[:variables]
-    notifies :reload, 'service[nagios]'
+    if ::File.open('/proc/1/comm').gets.chomp == 'systemd'
+      notifies :restart, 'service[nagios]'
+    else
+      notifies :reload, 'service[nagios]'
+    end
     backup 0
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ recipe 'nagios::pagerduty', 'Integrates contacts w/ PagerDuty API'
 depends 'apache2', '>= 2.0'
 depends 'zap', '>= 0.6.0'
 
-%w( build-essential php nginx nginx_simplecgi yum-epel nrpe ).each do |cb|
+%w( build-essential php nginx nginx_simplecgi yum-epel nrpe systemd ).each do |cb|
   depends cb
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -212,6 +212,14 @@ systemd_service 'nagios3' do
   only_if { ::File.open('/proc/1/comm').gets.chomp == 'systemd' } # systemd
 end
 
+template '/etc/init.d/nagios3' do
+  source 'nagios3.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+  only_if { ::File.open('/proc/1/comm').gets.chomp == 'systemd' } # systemd
+end
+
 service 'nagios' do
   service_name nagios_service_name
   supports :status => true, :restart => true, :reload => true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe 'systemd::journald'
+
 # workaround to allow for a nagios server install from source using the override attribute on debian/ubuntu (COOK-2350)
 if platform_family?('debian') && node['nagios']['server']['install_method'] == 'source'
   nagios_service_name = node['nagios']['server']['name']
@@ -195,6 +197,19 @@ nagios_conf 'servicedependencies'
 
 zap_directory node['nagios']['config_dir'] do
   pattern '*.cfg'
+end
+
+systemd_service 'nagios3' do
+  description 'Nagios3 server'
+  after %w( network.target )
+  install do
+    wanted_by 'multi-user.target'
+  end
+  service do
+    exec_start "/etc/init.d/nagios3 start"
+    exec_stop "/etc/init.d/nagios3 stop"
+  end
+  only_if { ::File.open('/proc/1/comm').gets.chomp == 'systemd' } # systemd
 end
 
 service 'nagios' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -206,8 +206,8 @@ systemd_service 'nagios3' do
     wanted_by 'multi-user.target'
   end
   service do
-    exec_start "/etc/init.d/nagios3 start"
-    exec_stop "/etc/init.d/nagios3 stop"
+    exec_start '/etc/init.d/nagios3 start'
+    exec_stop '/etc/init.d/nagios3 stop'
   end
   only_if { ::File.open('/proc/1/comm').gets.chomp == 'systemd' } # systemd
 end

--- a/templates/default/nagios3.erb
+++ b/templates/default/nagios3.erb
@@ -1,0 +1,29 @@
+#!/bin/sh
+# kFreeBSD do not accept scripts as interpreters, using #!/bin/sh and sourcing.
+if [ true != "$INIT_D_SCRIPT_SOURCED" ] ; then
+    set "$0" "$@"; INIT_D_SCRIPT_SOURCED=true . /lib/init/init-d-script
+fi
+### BEGIN INIT INFO
+# Provides:          skeleton
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Example initscript
+# Description:       This file should be used to construct scripts to be
+#                    placed in /etc/init.d.  This example start a
+#                    single forking daemon capable of writing a pid
+#                    file.  To get other behavoirs, implemend
+#                    do_start(), do_stop() or other functions to
+#                    override the defaults in /lib/init/init-d-script.
+### END INIT INFO
+
+# Author: Foo Bar <foobar@baz.org>
+#
+# Please remove the "Author" lines above and replace them
+# with your own name if you copy and modify this script.
+
+DAEMON=/usr/sbin/nagios3
+NAME="nagios3"
+DESC="nagios3 monitoring daemon"
+DAEMON_ARGS="-d /etc/nagios3/nagios.cfg"


### PR DESCRIPTION
#### What's this PR do?

This repo uses standard init scripts to launch Nagios. The default 'service' provider works just fine with Upstart on Ubuntu < 15, but fails with the Ubuntu > 15.04 which uses Systemd. This PR uses the systemd LWRP to add a service file that starts and stops using the /etc/init.d/nagios3 script.
#### Where should the reviewer start?

`recipes/default.rb` now includes the systemd recipe and the systemd_service block to create the systemd config descriptor.
#### How should this be manually tested? Have you personally tested it?

I've added the default recipe to a Vagrant provisioned Ubuntu 15.04 box and things worked as expected. 
#### Have unit/functional tests been added?

No additional tests have been added. The existing tests should pass as expected. If they don't, this PR should be rejected.
