### PR TITLE
Adding result_limit to cgi.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Example: `default['nagios']['conf']['cfg_dir'] = [ '/etc/nagios/conf.d' , '/usr/
  * `node['nagios']['cgi']['authorized_for_all_host_commands']`          - Defaults to '*'
  * `node['nagios']['cgi']['default_statusmap_layout']`                  - Defaults to 5
  * `node['nagios']['cgi']['default_statuswrl_layout']`                  - Defaults to 4
+ * `node['nagios']['cgi']['result_limit']`                              - Defaults to 100
  * `node['nagios']['cgi']['escape_html_tags']`                          - Defaults to 0
  * `node['nagios']['cgi']['action_url_target']`                         - Defaults to '_blank'
  * `node['nagios']['cgi']['notes_url_target']`                          - Defaults to '_blank'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -211,6 +211,7 @@ default['nagios']['cgi']['authorized_for_all_service_commands']      = '*'
 default['nagios']['cgi']['authorized_for_all_host_commands']         = '*'
 default['nagios']['cgi']['default_statusmap_layout']                 = 5
 default['nagios']['cgi']['default_statuswrl_layout']                 = 4
+default['nagios']['cgi']['result_limit']                             = 100
 default['nagios']['cgi']['escape_html_tags']                         = 0
 default['nagios']['cgi']['action_url_target']                        = '_blank'
 default['nagios']['cgi']['notes_url_target']                         = '_blank'

--- a/templates/default/cgi.cfg.erb
+++ b/templates/default/cgi.cfg.erb
@@ -209,6 +209,14 @@ ping_syntax=/bin/ping -n -U -c 5 $HOSTADDRESS$
 
 refresh_rate=90
 
+# DEFAULT PAGE LIMIT
+# This option allows you to specify the default number of results
+# displayed on the status.cgi.  This number can be adjusted from
+# within the UI after the initial page load. Setting this to 0
+# will show all results.
+
+result_limit=<%= node['nagios']['cgi']['result_limit'] %>
+
 # ESCAPE HTML TAGS
 # This option determines whether HTML tags in host and service
 # status output is escaped in the web interface.  If enabled,


### PR DESCRIPTION
Some people like to remove pagination from Nagios, enabling easier find-on-page searches. To do so you must set `result_limit=0`in `cgi.cfg`, which was not available in the existing template.
