### PR TITLE
make service groups do negation for removed hostgroups

### DIFF
--- a/libraries/base.rb
+++ b/libraries/base.rb
@@ -24,7 +24,8 @@ class Nagios
   class Base
     attr_accessor :register,
                   :name,
-                  :use
+                  :use,
+                  :not_modifiers
 
     def initialize
       @add_modifiers = {}

--- a/libraries/servicegroup.rb
+++ b/libraries/servicegroup.rb
@@ -120,17 +120,23 @@ class Nagios
       result
     end
 
+    # rubocop:disable MethodLength
     def lookup_hostgroup_members
       hostgroup_hash = {}
       @members.each do |service_name, service_obj|
         hostgroup_array = []
-        service_obj.hostgroups.each do |_, hostgroup_obj|
-          hostgroup_obj.members.each { |host_name, _| hostgroup_array << host_name }
+        service_obj.hostgroups.each do |hostgroup_name, hostgroup_obj|
+          if service_obj.not_modifiers['hostgroup_name'][hostgroup_name] != '!'
+            hostgroup_array += hostgroup_obj.members.keys
+          else
+            hostgroup_array -= hostgroup_obj.members.keys
+          end
         end
         hostgroup_hash[service_name] = hostgroup_array
       end
       convert_hostgroup_hash(hostgroup_hash)
     end
+    # rubocop:enable MethodLength
 
     def merge_members(obj)
       obj.members.each { |m| push(m) }

--- a/libraries/servicegroup.rb
+++ b/libraries/servicegroup.rb
@@ -111,8 +111,8 @@ class Nagios
 
     def convert_hostgroup_hash(hash)
       result = []
-      hash.each do |group_name, group_members|
-        group_members.each do |member|
+      hash.sort.to_h.each do |group_name, group_members|
+        group_members.sort.each do |member|
           result << member
           result << group_name
         end

--- a/test/integration/data_bags/nagios_services/selective_service.json
+++ b/test/integration/data_bags/nagios_services/selective_service.json
@@ -1,0 +1,6 @@
+{
+  "id": "selective_service",
+  "hostgroup_name": ["both_hosts", "!hostgroup_a"],
+  "command_line": "$USER1$/dodge",
+  "servicegroups": "selective_services"
+}

--- a/test/integration/data_bags/nagios_unmanagedhosts/host_a.json
+++ b/test/integration/data_bags/nagios_unmanagedhosts/host_a.json
@@ -6,5 +6,5 @@
   "alias": "Host A Alias Name",
   "environment": "_default",
   "display_name": "Host A Display Name",
-  "hostgroups": "hostgroup_a"
+  "hostgroups": ["hostgroup_a", "both_hosts"]
 }

--- a/test/integration/data_bags/nagios_unmanagedhosts/host_b.json
+++ b/test/integration/data_bags/nagios_unmanagedhosts/host_b.json
@@ -4,5 +4,5 @@
   "alias": "Host B Alias Name",
   "display_name": "Host B Display Name",
   "environment": "_default",
-  "hostgroups": "hostgroup_b"
+  "hostgroups": ["hostgroup_b", "both_hosts"]
 }

--- a/test/integration/server/serverspec/nagios_config_spec.rb
+++ b/test/integration/server/serverspec/nagios_config_spec.rb
@@ -135,6 +135,7 @@ describe 'Nagios Configuration' do
   file_servicegroups = []
   file_servicegroups << 'servicegroup_name.*servicegroup_a\n\s*members.*host_a_alt,service_a,host_a_alt,service_b,host_b,service_b,host_b,service_c'
   file_servicegroups << 'servicegroup_name.*servicegroup_b\n\s*members.*host_b,service_c'
+  file_servicegroups << 'servicegroup_name.*selective_services\n\s*members\s*host_b,selective_service'
 
   file_servicegroups.each do |line|
     describe file("#{path_config_dir}/servicegroups.cfg") do


### PR DESCRIPTION
The service group object reaches into the service objects for its hostgroup relations. So it needs to understand negated hostgroups. This should pull the negated hosts out of the service group member list, and add some checks to make sure it works.
