### PR TITLE
Allow AWS region restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Example: `default['nagios']['conf']['cfg_dir'] = [ '/etc/nagios/conf.d' , '/usr/
 * `node['nagios']['monitored_environments']` - If multi_environment_monitoring is 'true' nagios will monitor nodes in all environments. If monitored_environments is defined then nagios will monitor only hosts in the list of environments defined. For ex: ['prod', 'beta'] will monitor only hosts in 'prod' and 'beta' chef_environments. Defaults to '[]' - and all chef environments will be monitored by default.
 * `node['nagios']['monitoring_interface']` - If set, will use the specified interface for all nagios monitoring network traffic. Defaults to `nil`
 * `node['nagios']['exclude_tag_host']` - If set, hosts tagged with this value will be excluded from nagios monitoring.  Defaults to ''
+* `node['nagios']['aws_region_restrict']` - If set, host list will be restricted hosts in availability zones from the defined regions ('aws_regions' attribute).  Defaults to false 
+* `node['nagios']['aws_regions']` - If 'aws_region_restrict' attribute is set to true, only hosts from the defined regions will be monitored.  Defaults to '[]'
 
 * `node['nagios']['server']['install_method']` - whether to install from package or source. Default chosen by platform based on known packages available for Nagios: debian/ubuntu 'package', redhat/centos/fedora/scientific: source
 * `node['nagios']['server']['install_yum-epel']` - whether to install the EPEL repo or not (only applies to RHEL platform family). The default value is `true`. Set this to `false` if you do not wish to install the EPEL RPM; in this scenario you will need to make the relevant packages available via another method e.g. local repo, or install from source.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -227,6 +227,6 @@ default['apache']['mpm'] = 'prefork'
 default['nagios']['source']['add_build_commands'] = ['make install-exfoliation']
 default['nagios']['allowed_ips'] = []
 
-# restrict to AWS AZ
-default['nagios']['aws_zone_restrict'] = false
-default['nagios']['aws_zones']         = [ ]
+# restrict to AWS region(s) ie 'us-west-2'
+default['nagios']['aws_region_restrict'] = false
+default['nagios']['aws_regions']         = [ ]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -229,4 +229,4 @@ default['nagios']['allowed_ips'] = []
 
 # restrict to AWS region(s) ie 'us-west-2'
 default['nagios']['aws_region_restrict'] = false
-default['nagios']['aws_regions']         = [ ]
+default['nagios']['aws_regions']         = []

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -226,3 +226,7 @@ default['apache']['mpm'] = 'prefork'
 # attribute to add commands to source build
 default['nagios']['source']['add_build_commands'] = ['make install-exfoliation']
 default['nagios']['allowed_ips'] = []
+
+# restrict to AWS AZ
+default['nagios']['aws_zone_restrict'] = false
+default['nagios']['aws_zones']         = [ ]

--- a/recipes/_load_default_config.rb
+++ b/recipes/_load_default_config.rb
@@ -24,18 +24,16 @@ Chef::Log.info('Beginning search for nodes.  This may take some time depending o
 multi_env = node['nagios']['monitored_environments']
 multi_env_search = multi_env.empty? ? '' : ' AND (chef_environment:' + multi_env.join(' OR chef_environment:') + ')'
 
-if node['nagios']['multi_environment_monitoring']
-  search = "name:*#{multi_env_search}"
-else
-  search = "name:* AND chef_environment:#{node.chef_environment}"
-end
+search = if node['nagios']['multi_environment_monitoring']
+           "name:*#{multi_env_search}"
+         else
+           "name:* AND chef_environment:#{node.chef_environment}"
+         end
 
 aws_regions = node['nagios']['aws_regions']
 aws_region_search = aws_regions.empty? ? '' : ' AND (placement_availability_zone:' + aws_regions.join('* OR placement_availability_zone:') + '*)'
 
-if node['nagios']['aws_region_restrict']
-  search = search + aws_region_search
-end
+search += aws_region_search if node['nagios']['aws_region_restrict']
 
 nodes = search(:node, search)
 

--- a/recipes/_load_default_config.rb
+++ b/recipes/_load_default_config.rb
@@ -30,11 +30,11 @@ else
   search = "name:* AND chef_environment:#{node.chef_environment}"
 end
 
-aws_zones = node['nagios']['aws_zones']
-aws_zone_search = aws_zones.empty? ? '' : ' AND (placement_availability_zone:' + aws_zones.join('* OR placement_availability_zone:') + '*)'
+aws_regions = node['nagios']['aws_regions']
+aws_region_search = aws_regions.empty? ? '' : ' AND (placement_availability_zone:' + aws_regions.join('* OR placement_availability_zone:') + '*)'
 
-if node['nagios']['aws_zone_restrict']
-  search = search + aws_zone_search
+if node['nagios']['aws_region_restrict']
+  search = search + aws_region_search
 end
 
 nodes = search(:node, search)

--- a/recipes/_load_default_config.rb
+++ b/recipes/_load_default_config.rb
@@ -37,8 +37,6 @@ if node['nagios']['aws_zone_restrict']
   search = search + aws_zone_search
 end
 
-log("THIS IS THE SEARCH:\n"+search)
-
 nodes = search(:node, search)
 
 if nodes.empty?


### PR DESCRIPTION
feature add: a switch that restricts monitoring to node instances within defined AWS regions
