### PR TITLE
Change nginx deps to chef_nginx

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -15,7 +15,7 @@ recipe 'nagios::pagerduty', 'Integrates contacts w/ PagerDuty API'
 depends 'apache2', '>= 2.0'
 depends 'zap', '>= 0.6.0'
 
-%w( build-essential php nginx nginx_simplecgi yum-epel nrpe ).each do |cb|
+%w( build-essential php chef_nginx nginx_simplecgi yum-epel nrpe ).each do |cb|
   depends cb
 end
 

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -30,7 +30,7 @@ if platform_family?('rhel') || platform_family?('fedora')
   end
 end
 
-include_recipe 'nginx'
+include_recipe 'chef_nginx'
 
 %w(default 000-default).each do |disable_site|
   nginx_site disable_site do


### PR DESCRIPTION
The nginx cookbook is deprecated for the chef_nginx. So this cookbooks should use the supported chef_nginx dependancy.