### PR TITLE
Fix rubocop offenses

### DIFF
--- a/libraries/command.rb
+++ b/libraries/command.rb
@@ -84,7 +84,7 @@ class Nagios
     def config_options
       {
         'command_name' => 'command_name',
-        'command_line' => 'command_line'
+        'command_line' => 'command_line',
       }
     end
   end

--- a/libraries/contact.rb
+++ b/libraries/contact.rb
@@ -218,7 +218,7 @@ class Nagios
         'can_submit_commands'           => 'can_submit_commands',
         'retain_status_information'     => 'retain_status_information',
         'retain_nonstatus_information'  => 'retain_nonstatus_information',
-        'register'                      => 'register'
+        'register'                      => 'register',
       }
     end
 

--- a/libraries/contactgroup.rb
+++ b/libraries/contactgroup.rb
@@ -100,7 +100,7 @@ class Nagios
         'members_list'              => 'members',
         'contactgroup_members_list' => 'contactgroup_members',
         'alias'                     => 'alias',
-        'register'                  => 'register'
+        'register'                  => 'register',
       }
     end
 

--- a/libraries/host.rb
+++ b/libraries/host.rb
@@ -396,7 +396,7 @@ class Nagios
         'statusmap_image'              => 'statusmap_image',
         '_2d_coords'                   => '2d_coords',
         '_3d_coords'                   => '3d_coords',
-        'register'                     => 'register'
+        'register'                     => 'register',
       }
     end
     # rubocop:enable MethodLength

--- a/libraries/hostdependency.rb
+++ b/libraries/hostdependency.rb
@@ -165,7 +165,7 @@ class Nagios
         'hostgroup_name_list'           => 'hostgroup_name',
         'inherits_parent'               => 'inherits_parent',
         'execution_failure_criteria'    => 'execution_failure_criteria',
-        'notification_failure_criteria' => 'notification_failure_criteria'
+        'notification_failure_criteria' => 'notification_failure_criteria',
       }
     end
     # rubocop:enable MethodLength

--- a/libraries/hostescalation.rb
+++ b/libraries/hostescalation.rb
@@ -157,7 +157,7 @@ class Nagios
         'first_notification'    => 'first_notification',
         'last_notification'     => 'last_notification',
         'notification_interval' => 'notification_interval',
-        'register'              => 'register'
+        'register'              => 'register',
       }
     end
     # rubocop:enable MethodLength

--- a/libraries/hostgroup.rb
+++ b/libraries/hostgroup.rb
@@ -106,7 +106,7 @@ class Nagios
         'notes'                  => 'notes',
         'notes_url'              => 'notes_url',
         'action_url'             => 'action_url',
-        'register'               => 'register'
+        'register'               => 'register',
       }
     end
     # rubocop:enable MethodLength

--- a/libraries/service.rb
+++ b/libraries/service.rb
@@ -438,7 +438,7 @@ class Nagios
         'action_url'                   => 'action_url',
         'icon_image'                   => 'icon_image',
         'icon_image_alt'               => 'icon_image_alt',
-        'register'                     => 'register'
+        'register'                     => 'register',
       }
     end
     # rubocop:enable MethodLength

--- a/libraries/servicedependency.rb
+++ b/libraries/servicedependency.rb
@@ -198,7 +198,7 @@ class Nagios
         'hostgroup_name_list'              => 'hostgroup_name',
         'inherits_parent'                  => 'inherits_parent',
         'execution_failure_criteria'       => 'execution_failure_criteria',
-        'notification_failure_criteria'    => 'notification_failure_criteria'
+        'notification_failure_criteria'    => 'notification_failure_criteria',
       }
     end
     # rubocop:enable MethodLength

--- a/libraries/serviceescalation.rb
+++ b/libraries/serviceescalation.rb
@@ -179,7 +179,7 @@ class Nagios
         'first_notification'     => 'first_notification',
         'last_notification'      => 'last_notification',
         'notification_interval'  => 'notification_interval',
-        'register'               => 'register'
+        'register'               => 'register',
       }
     end
     # rubocop:enable MethodLength

--- a/libraries/servicegroup.rb
+++ b/libraries/servicegroup.rb
@@ -104,7 +104,7 @@ class Nagios
         'alias'                     => 'alias',
         'notes'                     => 'notes',
         'notes_url'                 => 'notes_url',
-        'action_url'                => 'action_url'
+        'action_url'                => 'action_url',
       }
     end
 

--- a/libraries/timeperiod.rb
+++ b/libraries/timeperiod.rb
@@ -148,7 +148,7 @@ class Nagios
       {
         'timeperiod_name' => 'timeperiod_name',
         'alias'           => 'alias',
-        'exclude'         => 'exclude'
+        'exclude'         => 'exclude',
       }
     end
 

--- a/recipes/_load_default_config.rb
+++ b/recipes/_load_default_config.rb
@@ -57,7 +57,7 @@ nagios_timeperiod '24x7' do
                        'wednesday' => '00:00-24:00',
                        'thursday'  => '00:00-24:00',
                        'friday'    => '00:00-24:00',
-                       'saturday'  => '00:00-24:00'
+                       'saturday'  => '00:00-24:00',
                      }
 end
 

--- a/recipes/pagerduty.rb
+++ b/recipes/pagerduty.rb
@@ -104,7 +104,7 @@ nagios_command 'notify-service-by-pagerduty' do
 end
 
 nagios_command 'notify-host-by-pagerduty' do
-  options 'command_line' => ::File.join(node['nagios']['plugin_dir'], 'notify_pagerduty.pl') + ' enqueue -f pd_nagios_object=host -f pd_description="$HOSTNAME$ : $SERVICEDESC$"' 
+  options 'command_line' => ::File.join(node['nagios']['plugin_dir'], 'notify_pagerduty.pl') + ' enqueue -f pd_nagios_object=host -f pd_description="$HOSTNAME$ : $SERVICEDESC$"'
 end
 
 unless node['nagios']['pagerduty']['key'].nil? || node['nagios']['pagerduty']['key'].empty?

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -8,11 +8,11 @@ describe 'nagios::default' do
                               'groups' => ['sysadmin'],
                               'nagios' => {
                                 'pager' => 'nagiosadmin_pager@example.com',
-                                'email' => 'nagiosadmin@example.com'
-                              }
+                                'email' => 'nagiosadmin@example.com',
+                              },
                             },
                  'user2' => { 'id'     => 'bsmith',
-                              'groups' => ['users']
+                              'groups' => ['users'],
                             })
     end.converge(described_recipe)
   end

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -9,12 +9,12 @@ describe 'nagios::default' do
                                           'groups' => ['sysadmin'],
                                           'nagios' => {
                                             'pager' => 'nagiosadmin_pager@example.com',
-                                            'email' => 'nagiosadmin@example.com'
-                                          }
+                                            'email' => 'nagiosadmin@example.com',
+                                          },
                                         },
                                         'user2' => {
                                           'id' => 'bsmith',
-                                          'groups' => ['users']
+                                          'groups' => ['users'],
                                         })
     end.converge(described_recipe)
   end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -10,12 +10,12 @@ describe 'nagios::default' do
                                           'groups' => ['sysadmin'],
                                           'nagios' => {
                                             'pager' => 'nagiosadmin_pager@example.com',
-                                            'email' => 'nagiosadmin@example.com'
-                                          }
+                                            'email' => 'nagiosadmin@example.com',
+                                          },
                                         },
                                         'user2' => {
                                           'id' => 'bsmith',
-                                          'groups' => ['users']
+                                          'groups' => ['users'],
                                         })
     end.converge(described_recipe)
   end


### PR DESCRIPTION
This PR fix almost all the offenses detected by rubocop.

There are 2 unfixed `Redundant return` because I think it's better to have them,
so I let you decide how you deal with those two.

Let me know if and how I can help release a new version of this cookbook with the new `chef_nginx` dependancy.

Thanks