### PR TITLE
Fixed a platform_family check in the apache template

### DIFF
--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -18,7 +18,7 @@
   CustomLog       <%= node['apache']['log_dir'] %>/nagios_access.log combined
   ErrorLog        <%= node['apache']['log_dir'] %>/nagios_error.log
 
-<% if node.platform_family == 'debian' && node['nagios']['server']['install_method'] == 'package'-%>
+<% if node['platform_family'] == 'debian' && node['nagios']['server']['install_method'] == 'package'-%>
   Alias /stylesheets /etc/<%= node['nagios']['server']['vname'] %>/stylesheets
   Alias /nagios3/stylesheets /etc/<%= node['nagios']['server']['vname'] %>/stylesheets
 <% end -%>


### PR DESCRIPTION
### Description

Running the cookbook with the apache template threw an error:

> undefined method `platform_family' for #<Chef::Node::Attribute:0x0000000396e4e0>

### Issues Resolved

Fixed the error to refer to the correct property.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
