### PR TITLE
Depend on nginx instead of chef_nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The functionality that was previously in the nagios::client recipe has been move
 
 - apache2 4.0 or greater
 - build-essential
-- chef_nginx
+- nginx
 - php
 - yum-epel
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,10 +13,11 @@ recipe 'default', 'Installs Nagios server.'
 recipe 'nagios::pagerduty', 'Integrates contacts w/ PagerDuty API'
 
 depends 'apache2', '>= 4.0'
+depends 'nginx', '>= 7.0'
 depends 'php-fpm', '>= 0.7.9'
 depends 'zap', '>= 0.6.0'
 
-%w( build-essential php nginx yum-epel nrpe ).each do |cb|
+%w( build-essential php yum-epel nrpe ).each do |cb|
   depends cb
 end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ depends 'apache2', '>= 4.0'
 depends 'php-fpm', '>= 0.7.9'
 depends 'zap', '>= 0.6.0'
 
-%w( build-essential php chef_nginx yum-epel nrpe ).each do |cb|
+%w( build-essential php nginx yum-epel nrpe ).each do |cb|
   depends cb
 end
 

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -18,7 +18,7 @@
 
 node.default['nagios']['server']['web_server'] = 'nginx'
 
-include_recipe 'chef_nginx'
+include_recipe 'nginx'
 
 node.default['php-fpm']['pools']['www']['user'] = node['nginx']['user']
 node.default['php-fpm']['pools']['www']['group'] = node['nginx']['group']


### PR DESCRIPTION
Depend on `nginx` instead of `chef_nginx`.