### PR TITLE
Skip definitions whose name starts with "!"

### DIFF
--- a/libraries/base.rb
+++ b/libraries/base.rb
@@ -157,6 +157,7 @@ class Nagios
     def get_definition(options, group)
       return nil if to_s == '*'
       return nil if to_s == 'null'
+      return nil if to_s.start_with? '!'
       d = ["define #{group} {"]
       d += get_definition_options(options)
       d += ['}']


### PR DESCRIPTION
### Description

Addresses #560 Does *not* prevent the invalid objects from being created, but it does prevent them from being output in the list of definitions when templates are rendered.

### Issues Resolved

#560  

### Check List

This is a one-liner, no docs required. I can find time for extra testing if you feel it's necessary upon review.
