### PR TITLE
Remove call to php::module_gd recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Copyright 2009, 37signals
 Copyright 2009-2017, Chef Software, Inc
 Copyright 2012, Webtrends Inc.
 Copyright 2013-2014, Limelight Networks, Inc.
+Copyright 2018, Oracle and/or its affiliates. All rights reserved
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -215,6 +215,13 @@ default['nagios']['server']['nginx_dispatch']['cgi_url']  =
   'unix:/var/run/fcgiwrap.socket'
 default['nagios']['server']['nginx_dispatch']['php_url']  =
   'unix:/var/run/php-fpm-www.sock'
+default['nagios']['php_gd_package']                    =
+  case node['platform_family']
+  when 'rhel'
+    'php-gd'
+  else
+    'php5-gd'
+  end
 default['nagios']['server']['stop_apache']             = false
 default['nagios']['server']['normalize_hostname']      = false
 default['nagios']['server']['load_default_config']     = true

--- a/recipes/server_source.rb
+++ b/recipes/server_source.rb
@@ -22,7 +22,8 @@
 # Package pre-reqs
 include_recipe 'build-essential'
 include_recipe 'php::default'
-include_recipe 'php::module_gd'
+
+package node['nagios']['php_gd_package']
 
 # the source install of nagios from this recipe does not include embedded perl support
 # so unless the user explicitly set the p1_file attribute, we want to clear it


### PR DESCRIPTION
### Description

The module_gd recipe in the php cookbook has been deprecated. This moves the package install to the server_source recipe.

### Issues Resolved

#568 

Current php cookbook is incompatible with this one until this change due to deprecation of the module_gd recipe.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
