### PR TITLE
fall back to node's PD key when using nagios_pagerduty databag

### DIFF
--- a/recipes/pagerduty.rb
+++ b/recipes/pagerduty.rb
@@ -139,7 +139,7 @@ pagerduty_contacts.each do |contact|
             'host_notification_options'     => contact['host_notification_options'] || 'd,r',
             'service_notification_commands' => 'notify-service-by-pagerduty',
             'host_notification_commands'    => 'notify-host-by-pagerduty',
-            'pager'                         => contact['key'] || contact['pagerduty_key'],
+            'pager'                         => contact['key'] || contact['pagerduty_key'] || node['nagios']['pagerduty']['key'],
             'contactgroups'                 => contact['contactgroups']
   end
 end


### PR DESCRIPTION
### Description

For the purpose of splitting host and service alerts to pagerduty, we prefer to use an environment-wide pagerduty key with separate contacts for host and service alerts. I couldn't find any way to easily support that without this patch.

