### PR TITLE
Require Chef 14+ and remove build-essential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the nagios cookbook.
 
+## UNRELEASED
+
+- Require Chef Infra Client 14.0+ and remove the need for the build-essential cookbook depenedency
+
 ## 8.1.0 (May 8, 2018)
 
 - Resolve incompatibilities with the latest PHP cookbook by installing php-gd
@@ -72,7 +76,7 @@ This file is used to list changes made in each version of the nagios cookbook.
 - #463 Adding '*' and 'null' as options.
 - #470 Adding option for wrapper cookbooks.
 - #470 Adding result_limit to cgi.cfg.
- 
+
 7.2.4
 -----
 ### Bug
@@ -111,8 +115,8 @@ This file is used to list changes made in each version of the nagios cookbook.
 - Fixing the services databag filter on environment.
 
 ### Improvement
-- Moving the LWRP's providers into definitions.  
-  This will remove some extra complexity and output will be  
+- Moving the LWRP's providers into definitions.
+  This will remove some extra complexity and output will be
   much nicer and debugging will be easier during the chef-converge.
 
 7.1.6
@@ -135,7 +139,7 @@ This file is used to list changes made in each version of the nagios cookbook.
 ### Improvement
 - Made test config os (in)dependent.
 - Added zap for config file cleanup.
-- Added encrypted user databag support. 
+- Added encrypted user databag support.
 - Added extra configuration tests.
 - Added gitter badge.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Chef
 
-Chef version 12.9+ is required
+Chef Infra Client version 14+ is required
 
 Because of the heavy use of search, this recipe will not work with Chef Solo, as it cannot do any searches without a server.
 
@@ -37,7 +37,6 @@ The functionality that was previously in the nagios::client recipe has been move
 ### Cookbooks
 
 - apache2 4.0 or greater
-- build-essential
 - nginx 7.0 or greater
 - php
 - yum-epel

--- a/libraries/service.rb
+++ b/libraries/service.rb
@@ -293,7 +293,6 @@ class Nagios
     def is_volatile=(arg)
       @is_volatile = check_bool(arg)
     end
-    # rubocop:enable Naming/PredicateName
 
     def active_checks_enabled=(arg)
       @active_checks_enabled = check_bool(arg)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,13 +6,12 @@ description      'Installs and configures Nagios server'
 version          '8.1.0'
 issues_url       'https://github.com/sous-chefs/nagios/issues'
 source_url       'https://github.com/sous-chefs/nagios'
-chef_version     '>= 12.9'
+chef_version     '>= 14'
 
 depends 'apache2', '>= 4.0'
 depends 'nginx', '>= 7.0'
 depends 'php-fpm', '>= 0.7.9'
 depends 'zap', '>= 0.6.0'
-depends 'build-essential', '>= 5.0'
 
 %w(php yum-epel nrpe).each do |cb|
   depends cb


### PR DESCRIPTION
Resolves cookstyle warnings and drops 2 cookbook deps total from each
node.

Signed-off-by: Tim Smith <tsmith@chef.io>