### PR TITLE
Nagios on Debian 10 installation issue: dependencies package.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -129,6 +129,11 @@ default['nagios']['server']['checksum']  = 'b0055c475683ce50d77b1536ff0cec9abf89
 default['nagios']['server']['src_dir']   = node['nagios']['server']['url'].split('/')[-1].chomp('.tar.gz')
 default['nagios']['server']['patches']   = []
 default['nagios']['server']['patch_url'] = nil
+default['nagios']['server']['dependencies'] = value_for_platform_family(
+  'rhel' => %w(openssl-devel gd-devel tar),
+  'debian' => %w(libssl-dev libgd2-xpm-dev bsd-mailx tar),
+  'default' => %w(libssl-dev libgd2-xpm-dev bsd-mailx tar)
+)
 
 # for server from packages installation
 if platform_family?('rhel', 'amazon')

--- a/recipes/server_source.rb
+++ b/recipes/server_source.rb
@@ -30,13 +30,7 @@ package node['nagios']['php_gd_package']
 # Note: the cookbook now defaults to Nagios 4.X which doesn't support embedded perl anyways
 node.default['nagios']['conf']['p1_file'] = nil
 
-pkgs = value_for_platform_family(
-  'rhel' => %w(openssl-devel gd-devel tar),
-  'debian' => %w(libssl-dev libgd2-xpm-dev bsd-mailx tar),
-  'default' => %w(libssl-dev libgd2-xpm-dev bsd-mailx tar)
-)
-
-pkgs.each do |pkg|
+node['nagios']['server']['dependencies'].each do |pkg|
   package pkg do
     action :install
   end


### PR DESCRIPTION
## Description
When installing Nagios on a debian 10 machine, the chef-client run fails because the recipe tries
to install the package libgd2-xpm-dev (among a few other errors).
By overriding node attributes, I was able to fix the installation, even if this cookbook doesn't seem
designed to work on debian 10. But this last problem was coming from a variable I could not override.

Details of the package is here https://packages.debian.org/fr/stretch/libgd2-xpm-dev.

In this PR, the dependencies are moved to default node attributes, so they can be overriden by cookbook's user.

Side-note:
I may come with a PR to fully support debian 10, but there is still work to do. This is not the purpose of this work.

### Issues Resolved

- I did not create an issue for not supporting a platform. Should I ?

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
