### PR TITLE
Enable Unified Mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,34 +8,17 @@ name: ci
       - main
 
 jobs:
-  delivery:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@main
-        env:
-          CHEF_LICENSE: accept-no-persist
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run yaml Lint
-        uses: actionshub/yamllint@main
-
-  mdl:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Markdown Lint
-        uses: actionshub/markdownlint@main
+  lint-unit:
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
+    permissions:
+      actions: write
+      checks: write
+      pull-requests: write
+      statuses: write
+      issues: write
 
   integration:
-    needs: [mdl, yamllint, delivery]
+    needs: lint-unit
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,12 @@ jobs:
     strategy:
       matrix:
         os:
+          - 'almalinux-8'
           - 'centos-7'
-          - 'centos-8'
+          - 'centos-stream-8'
           - 'debian-10'
+          - 'debian-11'
+          - 'rockylinux-8'
           - 'ubuntu-1804'
           - 'ubuntu-2004'
         suite:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the nagios cookbook.
 - Update tested platforms
 - Enable `unified_mode` and require Chef >= 15.3
 - Start nagios service
+- Include Nginx cookbook helper methods
 
 ## 10.0.4 - *2022-02-08*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the nagios cookbook.
 
 ## Unreleased
 
+- Remove delivery and move to calling RSpec directly via a reusable workflow
+
 ## 10.0.4 - *2022-02-08*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the nagios cookbook.
 - Remove delivery and move to calling RSpec directly via a reusable workflow
 - Update tested platforms
 - Enable `unified_mode` and require Chef >= 15.3
+- Start nagios service
 
 ## 10.0.4 - *2022-02-08*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ This file is used to list changes made in each version of the nagios cookbook.
 - Update tested platforms
 - Enable `unified_mode` and require Chef >= 15.3
 - Start nagios service
-- Include Nginx cookbook helper methods
 - Add support for Debian 11
+- Use www-data user for nginx on Debian based systems
 
 ## 10.0.4 - *2022-02-08*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the nagios cookbook.
 ## Unreleased
 
 - Remove delivery and move to calling RSpec directly via a reusable workflow
+- Update tested platforms
 
 ## 10.0.4 - *2022-02-08*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the nagios cookbook.
 - Enable `unified_mode` and require Chef >= 15.3
 - Start nagios service
 - Include Nginx cookbook helper methods
+- Add support for Debian 11
 
 ## 10.0.4 - *2022-02-08*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the nagios cookbook.
 
 - Remove delivery and move to calling RSpec directly via a reusable workflow
 - Update tested platforms
+- Enable `unified_mode` and require Chef >= 15.3
 
 ## 10.0.4 - *2022-02-08*
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Chef
 
-Chef Infra Client version 14+ is required
+Chef Infra Client version 15+ is required
 
 Because of the heavy use of search, this recipe will not work with Chef Solo, as it cannot do any searches without a server.
 
@@ -36,12 +36,12 @@ The functionality that was previously in the nagios::client recipe has been move
 
 ### Cookbooks
 
-- apache2 ~> 5.0
-- nginx ~> 9.0
+- apache2
+- nginx
 - nrpe
-- php >= 4.0
+- php
 - yum-epel
-- zap >= 0.6.0
+- zap
 
 ## Attributes
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Chef
 
-Chef Infra Client version 15+ is required
+Chef Infra Client version 15.3+ is required
 
 Because of the heavy use of search, this recipe will not work with Chef Solo, as it cannot do any searches without a server.
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -12,33 +12,42 @@ provisioner:
   name: dokken
 
 platforms:
+  - name: almalinux-8
+    driver:
+      image: dokken/almalinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: debian-10
     driver:
       image: dokken/debian-10
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
+      pid_one_command: /bin/systemd
 
   - name: centos-7
     driver:
       image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-8
+  - name: centos-stream-8
     driver:
-      image: dokken/centos-8
+      image: dokken/centos-stream-8
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -5,7 +5,7 @@ driver:
     - ["forwarded_port", {guest: 80, host: 8080}]
 
 provisioner:
-  name: chef_zero
+  name: chef_infra
   product_name: chef
   enforce_idempotency: true
   # This needs to be 3 due to the use of node searches
@@ -16,9 +16,12 @@ verifier:
   name: inspec
 
 platforms:
+  - name: almalinux-8
   - name: centos-7
-  - name: centos-8
+  - name: centos-stream-8
   - name: debian-10
+  - name: debian-11
+  - name: rockylinux-8
   - name: ubuntu-18.04
   - name: ubuntu-20.04
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -72,6 +72,22 @@ module NagiosCookbook
       end
     end
 
+    def nagios_nginx_user
+      if platform_family?('rhel')
+        'nginx'
+      else
+        'www-data'
+      end
+    end
+
+    def nagios_nginx_group
+      if platform_family?('rhel')
+        'nginx'
+      else
+        'www-data'
+      end
+    end
+
     def nagios_home
       if platform_family?('rhel')
         '/var/spool/nagios'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -34,7 +34,11 @@ module NagiosCookbook
       if platform_family?('rhel')
         'php-gd'
       elsif platform?('debian')
-        'php7.3-gd'
+        if node['platform_version'].to_i < 11
+          'php7.3-gd'
+        else
+          'php7.4-gd'
+        end
       elsif platform?('ubuntu')
         if node['platform_version'].to_f < 20.04
           'php7.2-gd'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs and configures Nagios server'
 version          '10.0.4'
 issues_url       'https://github.com/sous-chefs/nagios/issues'
 source_url       'https://github.com/sous-chefs/nagios'
-chef_version     '>= 15'
+chef_version     '>= 15.3'
 
 depends 'apache2', '>= 8.3'
 depends 'nginx', '>= 11.2'

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+Chef::DSL::Universal.include(Nginx::Cookbook::Helpers)
 node.default['nagios']['server']['web_server'] = 'nginx'
 
 nginx_install 'nagios' do

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-Chef::DSL::Universal.include(Nginx::Cookbook::Helpers)
 node.default['nagios']['server']['web_server'] = 'nginx'
 
 nginx_install 'nagios' do
@@ -31,10 +30,10 @@ end
 include_recipe 'php'
 
 php_fpm_pool 'nagios' do
-  user nginx_user
-  group nginx_group
-  listen_user nginx_user
-  listen_group nginx_group
+  user nagios_nginx_user
+  group nagios_nginx_group
+  listen_user nagios_nginx_user
+  listen_group nagios_nginx_group
 end
 
 package nagios_array(node['nagios']['server']['nginx_dispatch']['packages'])
@@ -44,7 +43,7 @@ if platform_family?('rhel')
     source 'spawn-fcgi.erb'
     notifies :start, 'service[spawn-fcgi]', :delayed
     variables(
-      nginx_user: nginx_user
+      nginx_user: nagios_nginx_user
     )
   end
 end
@@ -90,8 +89,8 @@ nginx_service 'nagios' do
   delayed_action :start
 end
 
-node.default['nagios']['web_user'] = nginx_user
-node.default['nagios']['web_group'] = nginx_user
+node.default['nagios']['web_user'] = nagios_nginx_user
+node.default['nagios']['web_group'] = nagios_nginx_user
 
 # configure the appropriate authentication method for the web server
 case node['nagios']['server_auth_method']

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -168,8 +168,11 @@ nagios_conf 'servicedependencies'
 
 service 'nagios' do
   service_name nagios_service_name
-  # don't start as it will cause issues on initial runs on Ubuntu platforms
-  action :enable
+  if ::File.exist?("#{nagios_config_dir}/services.cfg")
+    action [:enable, :start]
+  else
+    action :enable
+  end
 end
 
 # Remove distribution included config files that aren't managed via this cookbook

--- a/resources/command.rb
+++ b/resources/command.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 property :options, [Hash, Chef::DataBagItem], default: {}
+unified_mode true
 
 action :create do
   o = Nagios::Command.create(new_resource.name)

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -25,6 +25,7 @@ property :variables, Hash, default: {}
 property :config_subdir, [true, false], default: true
 property :source, String
 property :cookbook, String, default: 'nagios'
+unified_mode true
 
 action :create do
   conf_dir = new_resource.config_subdir ? node['nagios']['config_dir'] : node['nagios']['conf_dir']

--- a/resources/contact.rb
+++ b/resources/contact.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 property :options, [Hash, Chef::DataBagItem], default: {}
+unified_mode true
 
 action :create do
   o = Nagios::Contact.create(new_resource.name)

--- a/resources/contactgroup.rb
+++ b/resources/contactgroup.rb
@@ -19,6 +19,7 @@
 #
 
 property :options, [Hash, Chef::DataBagItem], default: {}
+unified_mode true
 
 action :create do
   o = Nagios::Contactgroup.create(new_resource.name)

--- a/resources/host.rb
+++ b/resources/host.rb
@@ -19,6 +19,7 @@
 #
 
 property :options, [Hash, Chef::DataBagItem], default: {}
+unified_mode true
 
 action :create do
   o = Nagios::Host.create(new_resource.name)

--- a/resources/hostdependency.rb
+++ b/resources/hostdependency.rb
@@ -19,6 +19,7 @@
 #
 
 property :options, [Hash, Chef::DataBagItem], default: {}
+unified_mode true
 
 action :create do
   o = Nagios::Hostdependency.create(new_resource.name)

--- a/resources/hostescalation.rb
+++ b/resources/hostescalation.rb
@@ -19,6 +19,7 @@
 #
 
 property :options, [Hash, Chef::DataBagItem], default: {}
+unified_mode true
 
 action :create do
   o = Nagios::Hostescalation.new(new_resource.name)

--- a/resources/hostgroup.rb
+++ b/resources/hostgroup.rb
@@ -19,6 +19,7 @@
 #
 
 property :options, [Hash, Chef::DataBagItem], default: {}
+unified_mode true
 
 action :create do
   o = Nagios::Hostgroup.create(new_resource.name)

--- a/resources/resource.rb
+++ b/resources/resource.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 property :options, [Hash, Chef::DataBagItem], default: {}
+unified_mode true
 
 action :create do
   o = Nagios::Resource.create(new_resource.name)

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -19,6 +19,7 @@
 #
 
 property :options, [Hash, Chef::DataBagItem], default: {}
+unified_mode true
 
 action :create do
   o = Nagios::Service.create(new_resource.name)

--- a/resources/servicedependency.rb
+++ b/resources/servicedependency.rb
@@ -19,6 +19,7 @@
 #
 
 property :options, [Hash, Chef::DataBagItem], default: {}
+unified_mode true
 
 action :create do
   o = Nagios::Servicedependency.create(new_resource.name)

--- a/resources/serviceescalation.rb
+++ b/resources/serviceescalation.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 property :options, [Hash, Chef::DataBagItem], default: {}
+unified_mode true
 
 action :create do
   o = Nagios::Serviceescalation.new(new_resource.name)

--- a/resources/servicegroup.rb
+++ b/resources/servicegroup.rb
@@ -19,6 +19,7 @@
 #
 
 property :options, [Hash, Chef::DataBagItem], default: {}
+unified_mode true
 
 action :create do
   o = Nagios::Servicegroup.create(new_resource.name)

--- a/resources/timeperiod.rb
+++ b/resources/timeperiod.rb
@@ -19,6 +19,7 @@
 #
 
 property :options, [Hash, Chef::DataBagItem], default: {}
+unified_mode true
 
 action :create do
   o = Nagios::Timeperiod.create(new_resource.name)


### PR DESCRIPTION
- Remove delivery and move to calling RSpec directly via a reusable workflow
- Update tested platforms
- Enable `unified_mode` and require Chef >= 15.3
- Start nagios service
