### PR TITLE
Add FollowSymLinks option to cgi-bin directory on Apache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the nagios cookbook.
 
 ## Unreleased
 
+- Add FollowSymLinks option to cgi-bin directory on Apache. This prevents running into AH00670 errors if a Rewrite rule
+  is used elsewhere in an apache configuration globally.
+
 ## 11.2.8 - *2024-04-29*
 
 ## 11.2.7 - *2024-04-29*

--- a/templates/apache2.conf.erb
+++ b/templates/apache2.conf.erb
@@ -27,7 +27,7 @@
   Alias /<%= node['nagios']['server']['vname'] %> <%= node['nagios']['docroot'] %>
 
   <Directory "<%= node['nagios']['cgi-bin'] %>">
-     Options ExecCGI
+     Options ExecCGI FollowSymLinks
      <% if node['nagios']['default_user_name'] -%>
      require all granted
      <% end -%>


### PR DESCRIPTION
This prevents running into AH00670 errors if a Rewrite rule is used elsewhere in
an apache configuration globally.

Signed-off-by: Lance Albertson <lance@osuosl.org>
