### PR TITLE
Add support for el9 based systems (php-fpm pool)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file is used to list changes made in each version of the nagios cookbook.
 
 Standardise files with files in sous-chefs/repo-management
 
+- Add support for el9 based systems
+- Centos stream 8 is EOL, switched to Centos stream 9
+
 ## 12.0.0 - *2024-07-02*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,10 +17,13 @@ verifier:
 
 platforms:
   - name: almalinux-8
-  - name: centos-stream-8
+  - name: almalinux-9
+  - name: centos-stream-9
   - name: debian-11
   - name: debian-12
+  - name: fedora-latest
   - name: rockylinux-8
+  - name: rockylinux-9
   - name: ubuntu-20.04
   - name: ubuntu-22.04
   - name: ubuntu-24.04

--- a/templates/apache2.conf.erb
+++ b/templates/apache2.conf.erb
@@ -34,7 +34,7 @@
   </Directory>
 
   <FilesMatch ".+\.ph(p[345]?|t|tml)$">
-     SetHandler application/x-httpd-php
+     SetHandler "<%= @apache_php_handler %>"
   </FilesMatch>
 
 <% if @https -%>


### PR DESCRIPTION
# Description

Add support for el9 based systems using php-fpm pool

## Issues Resolved

Missing support for el9 based systems where mod_php does not exist

## Check List

- [X] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
