### PR TITLE
fix: harden nagios object import against DataBagItem, immutable attrs, and Ruby 3.x

### DIFF
--- a/libraries/base.rb
+++ b/libraries/base.rb
@@ -63,15 +63,13 @@ class Nagios
         return true if expr == ''
       when 'Array', 'Hash', Array, Hash
         return true if expr.empty?
-      else
-        false
       end
       false
     end
 
     def check_bool(arg)
       return 1 if arg.class == TrueClass
-      return 1 if arg.to_s =~ /^y|yes|true|on|1$/i
+      return 1 if arg.to_s =~ /^(y|yes|true|on|1)$/i
       0
     end
 
@@ -84,15 +82,15 @@ class Nagios
       if options.include?(arg)
         Chef::Log.debug("#{self.class} #{self} adding option #{arg} for entry #{entry}")
       else
-        Chef::Log.fail("#{self.class} #{self} object error: Unknown option #{arg} for entry #{entry}")
+        Chef::Log.fatal("#{self.class} #{self} object error: Unknown option #{arg} for entry #{entry}")
         raise 'Unknown option'
       end
     end
 
     def check_state_options(arg, options, entry)
-      if arg.class == String
+      if arg.is_a?(String)
         check_state_options(arg.split(','), options, entry)
-      elsif arg.class == Array
+      elsif arg.is_a?(Array)
         arg.each { |a| check_state_option(a.strip, options, entry) }.join(',')
       else
         arg
@@ -129,7 +127,7 @@ class Nagios
     end
 
     def get_commands(obj)
-      obj.map(&:to_s).join(',')
+      obj.join(',')
     end
 
     def configured_option(method, option)
@@ -192,7 +190,7 @@ class Nagios
       when Array
         members = option
       else
-        Chef::Log.fail("Nagios fail: Use an Array or comma seperated String for option: #{option} within #{self.class}")
+        Chef::Log.fatal("Nagios fail: Use an Array or comma seperated String for option: #{option} within #{self.class}")
         raise 'Use an Array or comma seperated String for option'
       end
       members
@@ -253,7 +251,7 @@ class Nagios
           c = Nagios::Command.new(o.strip)
           n = Nagios.instance.find(c)
           if c == n
-            Chef::Log.fail("#{self.class} fail: Cannot find command #{o} please define it first.")
+            Chef::Log.fatal("#{self.class} fail: Cannot find command #{o} please define it first.")
             raise "#{self.class} fail: Cannot find command #{o} please define it first."
           else
             commands.push(n)
@@ -273,6 +271,9 @@ class Nagios
 
     def update_options(hash)
       return if blank?(hash)
+      # Chef::DataBagItem delegates [] but not iteration (#each is private on
+      # modern Chef Infra clients), so coerce it to a plain Hash before iterating.
+      hash = hash.to_hash if hash.respond_to?(:to_hash) && !hash.is_a?(Hash)
       update_hash_options(hash) if hash.respond_to?('each_pair')
     end
 
@@ -286,11 +287,15 @@ class Nagios
 
     def update_members(hash, option, object, remote = false)
       return if blank?(hash) || hash[option].nil?
-      if hash[option].is_a?(String) && hash[option].to_s.start_with?('+')
+      # Read the value out rather than rewriting hash[option] in place: hash may be
+      # a Chef::DataBagItem or an immutable node attribute (ImmutableMash), neither
+      # of which can be safely mutated.
+      value = hash[option]
+      if value.is_a?(String) && value.to_s.start_with?('+')
         @add_modifiers[option] = '+'
-        hash[option] = hash[option][1..-1]
+        value = value[1..-1]
       end
-      get_members(hash[option], object).each do |member|
+      get_members(value, object).each do |member|
         if member.start_with?('!')
           member = member[1..-1]
           @not_modifiers[option][member] = '!'

--- a/libraries/command.rb
+++ b/libraries/command.rb
@@ -48,7 +48,9 @@ class Nagios
 
     def import(hash)
       @command_line = hash if hash.class == String
-      hash['command_line'] == hash['command'] unless hash['command'].nil?
+      # Accept 'command' as an alias for 'command_line' (= not ==; the original
+      # comparison was a no-op that silently dropped such commands).
+      @command_line = hash['command'] unless hash.is_a?(String) || hash['command'].nil?
       update_options(hash)
     end
 

--- a/libraries/contactgroup.rb
+++ b/libraries/contactgroup.rb
@@ -78,7 +78,7 @@ class Nagios
           pop(self, obj)
         end
       when Nagios::Contactgroup
-        if @contactgroups_members.key?(obj.to_s)
+        if @contactgroup_members.key?(obj.to_s)
           pop_object(obj, @contactgroup_members)
           pop(self, obj)
         end

--- a/libraries/data_bag_helper.rb
+++ b/libraries/data_bag_helper.rb
@@ -14,7 +14,13 @@ class NagiosDataBags
   def get(bag_name)
     results = []
     if @bag_list.include?(bag_name)
-      Chef::Search::Query.new.search(bag_name.to_s, '*:*') { |rows| results << rows }
+      # Return plain (mutable) hashes. Chef::DataBagItem only delegates Hash
+      # methods through method_missing and makes #each private on modern Chef
+      # Infra clients, so callers that iterate items or write into them (as the
+      # load_* helpers do) would otherwise raise.
+      Chef::Search::Query.new.search(bag_name.to_s, '*:*') do |row|
+        results << (row.respond_to?(:raw_data) ? row.raw_data : row)
+      end
     else
       Chef::Log.info "The #{bag_name} data bag does not exist."
     end

--- a/libraries/hostgroup.rb
+++ b/libraries/hostgroup.rb
@@ -77,7 +77,7 @@ class Nagios
           obj.pop(obj)
         end
       when Nagios::Hostgroup
-        if @hostgroups_members.key?(obj.to_s)
+        if @hostgroup_members.key?(obj.to_s)
           pop_object(obj, @hostgroup_members)
           obj.pop(obj)
         end

--- a/libraries/nagios.rb
+++ b/libraries/nagios.rb
@@ -182,8 +182,8 @@ class Nagios
     when Nagios::Resource
       push_object(obj)
     else
-      Chef::Log.fail("Nagios error: Pushing unknown object: #{obj.class} into Nagios.instance")
-      raise
+      Chef::Log.fatal("Nagios error: Pushing unknown object: #{obj.class} into Nagios.instance")
+      raise "Nagios error: Pushing unknown object: #{obj.class} into Nagios.instance"
     end
   end
 

--- a/libraries/timeperiod.rb
+++ b/libraries/timeperiod.rb
@@ -40,7 +40,8 @@ class Nagios
     private
 
     def check_period(period)
-      return period if period =~ /^(([01]?[0-9]|2[0-3])\:[0-5][0-9]-([01]?[0-9]|2[0-4])\:[0-5][0-9],?)*$/
+      # Object#=~ was removed in Ruby 3.2, so match on the string form.
+      return period if period.to_s =~ /^(([01]?[0-9]|2[0-3])\:[0-5][0-9]-([01]?[0-9]|2[0-4])\:[0-5][0-9],?)*$/
       nil
     end
   end

--- a/spec/libraries/base_spec.rb
+++ b/spec/libraries/base_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'chef/data_bag_item'
+require 'chef/node/immutable_collections'
+require_relative '../../libraries/contact'
+require_relative '../../libraries/contactgroup'
+require_relative '../../libraries/command'
+require_relative '../../libraries/host'
+require_relative '../../libraries/hostgroup'
+
+RSpec.describe 'Nagios::Base' do
+  before { Nagios.instance.instance_variable_set(:@hostgroups, {}) }
+
+  describe '#update_options with a Chef::DataBagItem' do
+    let(:item) do
+      item = Chef::DataBagItem.new
+      item.data_bag('nagios_contacts')
+      item.raw_data = { 'id' => 'epager-contact', 'alias' => 'E Pager', 'email' => 'root@example.org' }
+      item
+    end
+
+    it 'imports without iterating the item directly' do
+      # Modern Chef Infra clients make Chef::DataBagItem#each private, so importing
+      # an item must not call #each on it (only on its Hash form).
+      allow(item).to receive(:each).and_raise(NoMethodError, "private method 'each' called for a Chef::DataBagItem")
+
+      contact = Nagios::Contact.new('epager-contact')
+      expect { contact.import(item) }.not_to raise_error
+      expect(contact.email).to eq('root@example.org')
+      expect(contact.alias).to eq('E Pager')
+    end
+  end
+
+  describe '#update_members with an immutable node attribute' do
+    it 'does not mutate the caller and never raises ImmutableAttributeModification' do
+      # push_node feeds node['nagios'] (an ImmutableMash) into Host#import; the '+'
+      # additive-inheritance rewrite must not write back into it.
+      attrs = Chef::Node::ImmutableMash.new('hostgroups' => '+linux,web')
+      host = Nagios::Host.new('web01')
+      expect { host.import(attrs) }.not_to raise_error
+      expect(attrs['hostgroups']).to eq('+linux,web') # unchanged
+    end
+  end
+
+  describe '#check_bool' do
+    let(:obj) { Nagios::Command.new('probe') }
+
+    it 'coerces only whole-string truthy values' do
+      %w(y yes true on 1).each { |v| expect(obj.send(:check_bool, v)).to eq(1) }
+      expect(obj.send(:check_bool, true)).to eq(1)
+    end
+
+    it 'does not match substrings such as none or monday' do
+      %w(none monday no false 0 yellow).each { |v| expect(obj.send(:check_bool, v)).to eq(0) }
+    end
+  end
+
+  describe 'Nagios::Command#import' do
+    it 'accepts command as an alias for command_line' do
+      command = Nagios::Command.new('check_thing')
+      command.import('command' => '$USER1$/check_thing')
+      expect(command.command_line).to eq('$USER1$/check_thing')
+    end
+  end
+end

--- a/spec/libraries/data_bag_helper_spec.rb
+++ b/spec/libraries/data_bag_helper_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'chef/data_bag_item'
+require 'chef/search/query'
+require_relative '../../libraries/data_bag_helper'
+
+RSpec.describe NagiosDataBags do
+  describe '#get' do
+    let(:item) do
+      item = Chef::DataBagItem.new
+      item.data_bag('nagios_services')
+      item.raw_data = { 'id' => 'load', 'check_command' => 'check_load' }
+      item
+    end
+
+    before do
+      query = instance_double(Chef::Search::Query)
+      allow(Chef::Search::Query).to receive(:new).and_return(query)
+      allow(query).to receive(:search).with('nagios_services', '*:*').and_yield(item)
+    end
+
+    it 'returns plain, mutable hashes rather than Chef::DataBagItem objects' do
+      result = described_class.new(['nagios_services']).get('nagios_services').first
+      expect(result).to be_a(Hash)
+      expect(result).not_to be_a(Chef::DataBagItem)
+      expect(result['check_command']).to eq('check_load')
+      # load_services et al. write into the item; that must not raise.
+      expect { result['check_command'] = 'check_other' }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
nagios_data_bag_config passes Chef::DataBagItem objects into the nagios object
resources. Nagios::Base#update_hash_options iterated them with #each, which
modern Chef Infra clients make private, so the converge failed while loading
any data-bag-defined object (nagios_contacts, nagios_services, ...):

  private method `each' called for a Chef::DataBagItem

Fix that and the sibling failures in the same object-loading path:

- update_options coerces its argument to a plain Hash before iterating,
  matching what nagios_pagerduty already does for its data bag contacts.
- NagiosDataBags#get returns plain hashes so load_services/load_templates/
  load_hosttemplates can write item['...'] and callers can iterate without
  relying on Chef::DataBagItem method_missing delegation.
- update_members reads the member value out instead of rewriting hash[option]
  in place, so importing a Chef::DataBagItem or an immutable node attribute
  (node['nagios'] via push_node) no longer raises
  ImmutableAttributeModification.
- Chef::Log.fail (which is Kernel#fail and raises) -> Chef::Log.fatal in
  base.rb and nagios.rb so error paths log and then raise the intended message
  instead of masking it.
- Command#import assigns command_line from a 'command' alias (was ==, a no-op
  that silently dropped the command).
- check_bool anchors its regex so values like 'none'/'monday' no longer coerce
  to true via substring match.
- check_state_options uses is_a? so immutable node-attribute arrays are still
  validated.
- Timeperiodentry#check_period matches on the string form (Object#=~ was
  removed in Ruby 3.2).
- Fix misspelled @hostgroups_members/@contactgroups_members ivars in
  Hostgroup#pop and Contactgroup#pop.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
