### PR TITLE
docs: document current PagerDuty contact-group behaviour

### DIFF
--- a/documentation/nagios_pagerduty.md
+++ b/documentation/nagios_pagerduty.md
@@ -34,3 +34,20 @@ nagios_pagerduty 'default' do
   key 'pagerduty-service-key'
 end
 ```
+
+## Notes on current behaviour
+
+- The PagerDuty contact (`pagerduty`, plus any contacts from `contact_data_bag`) is **created as a contact only** — it is **not** automatically added to the admin users group or to any contact group. In older versions the recipe added the PagerDuty user to the admin group; that is no longer the case.
+- To receive notifications, add the contact to a contact group explicitly, for example:
+
+```ruby
+nagios_contactgroup 'admins' do
+  options(
+    'alias' => 'Admins',
+    'members' => 'pagerduty'
+  )
+end
+```
+
+- Contacts loaded from `contact_data_bag` can declare their own groups via a `contactgroups` field in the data bag item; the standalone `key` contact (`pagerduty`) has no group membership unless you add it yourself.
+


### PR DESCRIPTION
## Summary

Per #493: the PagerDuty documentation did not reflect current behaviour — the contact is created but no longer added to the admin users group automatically.

## Changes

- `documentation/nagios_pagerduty.md`: new "## Notes on current behaviour" section:
  - states plainly that the PagerDuty contact is created as a contact **only** and is **not** automatically added to the admin group or any contact group (behaviour change from older versions)
  - shows how to add it to a contact group explicitly via `nagios_contactgroup`
  - documents that `contact_data_bag` contacts can declare `contactgroups` themselves

## Verification

- Behaviour statements cross-checked against `resources/pagerduty.rb`:
  - the standalone `pagerduty` contact is created without a `contactgroups` directive
  - data-bag contacts pass through `contact['contactgroups']`